### PR TITLE
do-not-land: implement support

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -4,7 +4,13 @@ cli:
     linux_x86_64: deded9e4c8db75e944e3c7bd67dcac9c635c26a08c30a8f7fc41fa81bacf6f36
   version: 0.1.21-alpha
 lint:
+  linters:
+    - name: horton
+      type: lsp_json
+      files: [ALL]
+      command: ["${workspace}/target/debug/horton", "--file", "${path}"]
   enabled:
     - gitleaks@7.5.0
+    - horton
     - prettier@2.3.2
 version: 0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2018"
 
 [dependencies]
 clap = "3.0.0-beta.4"
+regex = "1.5.4"
+serde = {version = "1.0.127" , features = ["derive"]}
+serde_json = "1.0.66"

--- a/src/lsp_json.rs
+++ b/src/lsp_json.rs
@@ -1,0 +1,46 @@
+extern crate serde;
+extern crate serde_json;
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub enum Severity {
+    Error,
+    Warning,
+    Information,
+    Hint,
+}
+
+#[derive(Serialize)]
+pub struct Position {
+    pub line: u64,
+    pub character: u64,
+}
+
+#[derive(Serialize)]
+pub struct Range {
+    pub start: Position,
+    pub end: Position,
+}
+
+#[derive(Serialize)]
+pub struct Diagnostic {
+    pub range: Range,
+    pub severity: Severity,
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Serialize)]
+pub struct LspJson {
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+impl LspJson {
+    pub fn to_string(&self) -> Result<String, String> {
+        return match serde_json::to_string(&self) {
+            serde_json::Result::Ok(s) => Ok(s),
+            serde_json::Result::Err(err) => Err(err.to_string()),
+        };
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,10 @@
+extern crate clap;
+extern crate regex;
+
+mod lsp_json;
+
 use clap::{AppSettings, Clap};
+use regex::Regex;
 use std::{
     fs::File,
     io::{BufRead, BufReader},
@@ -13,28 +19,61 @@ struct Opts {
     file: String,
 }
 
-fn lines_view(filename: &Path) -> Vec<String> 
-{
+fn lines_view(filename: &Path) -> Vec<String> {
     let file = match File::open(filename) {
         Ok(file) => file,
         Err(_) => panic!("Unable to open file {}", filename.display()),
     };
     let buffer = BufReader::new(file);
-    return buffer.lines().map( |l| l.expect("Could not parse line"))
-    .collect();
-    
+    return buffer
+        .lines()
+        .map(|l| l.expect("Could not parse line"))
+        .collect();
 }
 
 fn main() {
     let opts: Opts = Opts::parse();
-    let filename = opts.file;
 
-    // Assume all rules are enabled. 
+    let re = Regex::new(r"(?i)(DO[\s_-]+NOT[\s_-]+LAND)").unwrap();
 
-    // Read the contents of the file into a string before we pass it along to all the rules
+    let mut ret = lsp_json::LspJson {
+        diagnostics: Vec::new(),
+    };
 
-    let lines = lines_view(Path::new(&filename));
-    for line in lines {
-        println!("{:?}", line);
+    for (i, line) in lines_view(Path::new(&opts.file)).iter().enumerate() {
+        // NOCHECK(horton/do-not-land)
+        if line.trim_end().ends_with("NOCHECK(horton/do-not-land)") {
+            continue;
+        }
+        let maybe_match = re.find(&line);
+        if maybe_match.is_none() {
+            continue;
+        }
+        let m = maybe_match.unwrap();
+        ret.diagnostics.push(lsp_json::Diagnostic {
+            range: lsp_json::Range {
+                start: lsp_json::Position {
+                    line: i as u64,
+                    character: m.start() as u64,
+                },
+                end: lsp_json::Position {
+                    line: i as u64,
+                    character: m.end() as u64,
+                },
+            },
+            severity: lsp_json::Severity::Error,
+            // NOCHECK(horton/do-not-land)
+            code: "do-not-land".to_string(),
+            message: format!("Found '{}'", m.as_str()),
+        });
+    }
+
+    match ret.to_string() {
+        Ok(s) => {
+            println!("{}", s)
+        }
+        Err(err) => {
+            panic!("Failed to serialize diagnostics, error was: {}", err)
+        }
     }
 }


### PR DESCRIPTION
To see what this looks like:

```
cat >foo.md <<EOF
here's a markdown file

with a DO NOT LAND comment
                more do-not-land
AND dO nOt    LaNd
EOF
```
```
~/trunk/bazel-bin/trunk/cli/cli check -n
```

Still need to figure out how we want to set up tests and CI on this repo.