### PR TITLE
feat: fix release process and rename horton -> trunk-toolbox

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,4 +31,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create --target ${{ github.ref }} ${{ github.event.inputs.release_tag }} --generate-notes
-          gh release upload ${{ github.event.inputs.release_tag }} target/x86_64-unknown-linux-gnu/release/horton
+          gh release upload ${{ github.event.inputs.release_tag }} target/x86_64-unknown-linux-gnu/release/trunk-toolbox

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,8 @@ jobs:
       # TODO(sam): cargo build --locked
       - name: Build --release
         run: cargo build --release --target x86_64-unknown-linux-gnu
+        env:
+          HORTON_RELEASE: ${{ github.event.inputs.release_tag }}
 
       - name: Create GH release and upload binary
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ concurrency: ${{ github.workflow }}
 
 jobs:
   build_tag_and_release:
-    name: Build, Tag, and Release [ ${{ github.event.inputs.release_tag }}]
+    name: Build, Tag, and Release [ ${{ github.event.inputs.release_tag }} ]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,5 +30,5 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create ${{ github.event.inputs.release_tag }} --generate-notes
+          gh release create --target ${{ github.ref }} ${{ github.event.inputs.release_tag }} --generate-notes
           gh release upload ${{ github.event.inputs.release_tag }} target/x86_64-unknown-linux-gnu/release/horton

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
     inputs:
       release_tag:
         type: string
-        description: Tag to create (from latest main)
+        description: Tag to create
 concurrency: ${{ github.workflow }}
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 build = "build.rs"
 
 [lib]
-name = "trunk-toolbox"
+name = "horton"
 path = "src/lib.rs"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,16 @@
 [package]
-name = "horton"
-version = "0.0.0-sam.0"
+name = "trunk-toolbox"
+# build.rs bypasses package.version, instead using $HORTON_RELEASE and falls back to the current ref
+version = "0.0.0"
 authors = ["horton <horton@trunk.io>"]
 license = "MIT"
 description = "trunk custom issue finder"
 readme = "README.md"
 edition = "2021"
+build = "build.rs"
 
 [lib]
-name = "horton"
+name = "trunk-toolbox"
 path = "src/lib.rs"
 
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,18 @@
+use std::process::Command;
+
+fn main() {
+    // This is a workaround to allow the value of HORTON_RELEASE during `cargo build` to control
+    // the built version, as opposed to pulling the package version from Cargo.toml.
+    // See https://github.com/rust-lang/cargo/issues/6583#issuecomment-1259871885
+    println!("cargo:rerun-if-env-changed=HORTON_RELEASE");
+    if let Ok(val) = std::env::var("HORTON_RELEASE") {
+        println!("cargo:rustc-env=CARGO_PKG_VERSION={}", val);
+    } else {
+        let output = Command::new("git")
+            .args(&["rev-parse", "--abbrev-ref", "HEAD"])
+            .output()
+            .unwrap();
+        let git_ref = String::from_utf8(output.stdout).unwrap();
+        println!("cargo:rustc-env=CARGO_PKG_VERSION={}", git_ref);
+    }
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,4 +1,4 @@
-use git2::{Delta, DiffOptions, Repository};
+use git2::{Delta, DiffOptions, Oid, Repository};
 use std::collections::HashSet;
 use std::path::PathBuf;
 
@@ -21,7 +21,10 @@ pub struct NewOrModified {
 pub fn modified_since(upstream: &str) -> anyhow::Result<NewOrModified> {
     let repo = Repository::open(".")?;
 
-    let upstream_tree = repo.find_reference(upstream)?.peel_to_tree()?;
+    let upstream_tree = match repo.find_reference(upstream) {
+        Ok(reference) => reference.peel_to_tree()?,
+        _ => repo.find_object(Oid::from_str(upstream)?, None)?.peel_to_tree()?,
+    };
 
     let diff = {
         let mut diff_opts = DiffOptions::new();

--- a/src/git.rs
+++ b/src/git.rs
@@ -23,7 +23,9 @@ pub fn modified_since(upstream: &str) -> anyhow::Result<NewOrModified> {
 
     let upstream_tree = match repo.find_reference(upstream) {
         Ok(reference) => reference.peel_to_tree()?,
-        _ => repo.find_object(Oid::from_str(upstream)?, None)?.peel_to_tree()?,
+        _ => repo
+            .find_object(Oid::from_str(upstream)?, None)?
+            .peel_to_tree()?,
     };
 
     let diff = {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use horton::rules::pls_no_land::pls_no_land;
 use serde_sarif::sarif;
 
 #[derive(Parser, Debug)]
-#[clap(version = "0.1", author = "Trunk Technologies Inc.")]
+#[clap(version = env!("CARGO_PKG_VERSION"), author = "Trunk Technologies Inc.")]
 struct Opts {
     #[clap(long)]
     // #[arg(default_value_t = String::from("refs/heads/main"))]

--- a/tests/integration_testing.rs
+++ b/tests/integration_testing.rs
@@ -70,7 +70,7 @@ impl TestRepo {
     }
 
     pub fn run_horton(&self) -> Result<String, Box<dyn Error>> {
-        let mut cmd = Command::cargo_bin("horton")?;
+        let mut cmd = Command::cargo_bin("trunk-toolbox")?;
 
         cmd.env("RUST_LOG", "debug");
         cmd.arg("--upstream")


### PR DESCRIPTION
Per discussion with David and Chris, we're going with a more generic name because we don't expect this tool to build its own brand identity independent of trunk.

Also allow controlling the released version using `HORTON_RELEASE` (`TOOLBOX_RELEASE` reads weird without context). This has to be done manually in build.rs; the Rust ecosystem normally assumes that this is done via `package.version` in Cargo.toml, but that's a weird way to do things.

Sneak in a bugfix for resolving --upstream; we also now handle arbitrary hex OIDs.