### PR TITLE
feat: assorted improvements

### DIFF
--- a/src/rules/if_change_then_change.rs
+++ b/src/rules/if_change_then_change.rs
@@ -97,11 +97,11 @@ pub fn ictc(hunks: &Vec<Hunk>) -> anyhow::Result<Vec<diagnostic::Diagnostic>> {
             severity: diagnostic::Severity::Error,
             code: "if-change-then-change".to_string(),
             message: format!(
-                "{}[{}, {}) was modified, but no if-change-then-change block in {} was modified",
+                "Expected change in {} because {}[{}, {}) was modified",
+                b.thenchange.display(),
                 b.path.display(),
                 b.begin,
                 b.end,
-                b.thenchange.display()
             ),
         })
         .collect();

--- a/src/rules/if_change_then_change.rs
+++ b/src/rules/if_change_then_change.rs
@@ -97,11 +97,9 @@ pub fn ictc(hunks: &Vec<Hunk>) -> anyhow::Result<Vec<diagnostic::Diagnostic>> {
             severity: diagnostic::Severity::Error,
             code: "if-change-then-change".to_string(),
             message: format!(
-                "Expected change in {} because {}[{}, {}) was modified",
+                "Expected change in {} because {} was modified",
                 b.thenchange.display(),
                 b.path.display(),
-                b.begin,
-                b.end,
             ),
         })
         .collect();

--- a/src/rules/pls_no_land.rs
+++ b/src/rules/pls_no_land.rs
@@ -9,7 +9,7 @@ use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
 lazy_static::lazy_static! {
-    static ref RE: Regex = Regex::new(r"(?i)(DO[\s_-]+NOT[\s_-]+LAND)").unwrap();
+    static ref RE: Regex = Regex::new(r"(?i)(DO[\s_-]*NOT[\s_-]*LAND)").unwrap();
 }
 
 // Checks for $re and other forms thereof in source code
@@ -44,7 +44,7 @@ fn pls_no_land_impl(path: &PathBuf) -> anyhow::Result<Vec<diagnostic::Diagnostic
     let mut ret = Vec::new();
 
     for (i, line) in lines_view.iter().enumerate() {
-        if line.contains("trunk-ignore(|-begin|-end|-all)\\(horton/do-not-land\\)") {
+        if line.contains("trunk-ignore(|-begin|-end|-all)\\(trunk-toolbox/do-not-land\\)") {
             continue;
         }
 


### PR DESCRIPTION
Improve the diagnostic message for if-change-then-change to be more
actionable and support `DONOTLAND` as a do-not-land token.

Currently it looks like this:

![image](https://user-images.githubusercontent.com/512410/196557797-d3d1ffa4-6dc1-4221-bd7d-877dc6270464.png)
