### PR TITLE
fix(ictc): write tests, fix moved blocks & LFS, and more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ content_inspector = "0.2.4"
 assert_cmd = "2.0"
 function_name = "0.2.0"
 predicates = "2.1"
+spectral = "0.6.0"
 tempfile = "3.3.0"
 
 [profile.release]

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,11 +1,15 @@
-use git2::{Delta, DiffOptions, Oid, Repository};
+use git2::{AttrCheckFlags, AttrValue, Delta, DiffOptions, Repository};
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Hunk {
     pub path: PathBuf,
+
+    /// 1-indexed line number, inclusive
     pub begin: i64,
+
+    /// 1-indexed line number, exclusive
     pub end: i64,
 }
 
@@ -18,14 +22,24 @@ pub struct NewOrModified {
     pub paths: HashSet<PathBuf>,
 }
 
+fn is_lfs(repo: &Repository, path: &Path) -> bool {
+    // "filter" is the primary LFS attribute, see gitattributes(5)
+    // FILE_THEN_INDEX checks working tree then index; mimics git itself
+    // https://github.com/libgit2/libgit2/blob/v1.5.0/include/git2/attr.h#L104-L116
+    if let Ok(filter_bytes) = repo.get_attr_bytes(path, "filter", AttrCheckFlags::FILE_THEN_INDEX) {
+        let filter = AttrValue::from_bytes(filter_bytes);
+        filter.eq(&AttrValue::from_string(Some("lfs")))
+    } else {
+        false
+    }
+}
+
 pub fn modified_since(upstream: &str) -> anyhow::Result<NewOrModified> {
     let repo = Repository::open(".")?;
 
     let upstream_tree = match repo.find_reference(upstream) {
         Ok(reference) => reference.peel_to_tree()?,
-        _ => repo
-            .find_object(Oid::from_str(upstream)?, None)?
-            .peel_to_tree()?,
+        _ => repo.revparse_single(upstream)?.peel_to_tree()?,
     };
 
     let diff = {
@@ -35,39 +49,91 @@ pub fn modified_since(upstream: &str) -> anyhow::Result<NewOrModified> {
         repo.diff_tree_to_workdir_with_index(Some(&upstream_tree), Some(&mut diff_opts))?
     };
 
+    // Iterate through the git diff, building hunks that match the new or modified lines in the
+    // diff between the upstream and the working directory. Algorithm is as follows:
+    //
+    //      current_hunk = None
+    //      for (delta, hunk, line) in diff:
+    //          if old_lineno == 0, new_lineno == 0:
+    //              impossible; do nothing
+    //          if old_lineno nonzero, new_lineno == 0:
+    //              deleted line; do nothing
+    //          if old_lineno == 0, new_lineno nonzero:
+    //              new or modified line; create or append to current hunk
+    //          if old_lineno nonzero, new_lineno nonzero:
+    //              context line or moved line; terminate current hunk
+    //
+    // The reason we have to do this re-hunking is because if the line numbers of an ICTC block
+    // change - likely because more lines were added to the file preceding it - libgit2 will create
+    // a DiffHunk which includes the moved lines, so we can't just create one hunk per DiffHunk.
+    // Instead, we have to break up DiffHunk instances in up to N hunks, since we only care about
+    // the new/modified section of the diff.
+    //
+    // See https://docs.rs/git2/latest/git2/struct.Diff.html#method.foreach and the underlying API
+    // docs at https://libgit2.org/libgit2/#HEAD/group/diff/git_diff_foreach.
     let mut ret = NewOrModified::default();
+    let mut maybe_current_hunk: Option<Hunk> = None;
     diff.foreach(
         &mut |_, _| true,
         None,
-        Some(&mut |delta, hunk| {
-            match delta.status() {
-                Delta::Unmodified
-                | Delta::Added
-                | Delta::Modified
-                | Delta::Renamed
-                | Delta::Copied
-                | Delta::Untracked => {
-                    if let Some(path) = delta.new_file().path() {
-                        let path = path.to_path_buf();
-
-                        ret.paths.insert(path.clone());
-                        ret.hunks.push(Hunk {
-                            path,
-                            begin: hunk.new_start() as i64,
-                            end: (hunk.new_start() + hunk.new_lines()) as i64,
-                        });
-                    } else {
-                        // TODO(sam): accumulate errors and return them
-                        // See https://doc.rust-lang.org/rust-by-example/error/iter_result.html
-                        log::error!("Found git delta where new_file had no path");
+        None,
+        Some(&mut |delta, _, line| {
+            if let Some(path) = delta.new_file().path() {
+                if !is_lfs(&repo, path) {
+                    match delta.status() {
+                        Delta::Added
+                        | Delta::Copied
+                        | Delta::Untracked
+                        | Delta::Modified
+                        | Delta::Renamed => {
+                            if let Some(new_lineno) = line.new_lineno() {
+                                if line.old_lineno().is_none() {
+                                    maybe_current_hunk = maybe_current_hunk
+                                        .as_ref()
+                                        .map(|current_hunk| Hunk {
+                                            path: current_hunk.path.clone(),
+                                            begin: current_hunk.begin,
+                                            end: (new_lineno as i64) + 1,
+                                        })
+                                        .or_else(|| {
+                                            Some(Hunk {
+                                                path: path.to_path_buf(),
+                                                begin: new_lineno as i64,
+                                                end: (new_lineno as i64) + 1,
+                                            })
+                                        });
+                                } else if let Some(current_hunk) = &maybe_current_hunk {
+                                    log::info!("Appending current hunk {:#?}", current_hunk);
+                                    ret.paths.insert(current_hunk.path.clone());
+                                    ret.hunks.push(current_hunk.clone());
+                                    maybe_current_hunk = None;
+                                }
+                            }
+                        }
+                        Delta::Unmodified
+                        | Delta::Deleted
+                        | Delta::Ignored
+                        | Delta::Typechange
+                        | Delta::Unreadable
+                        | Delta::Conflicted => (),
                     }
                 }
-                _ => (),
             }
+            log::info!(
+                "line_cb {:#?} {:#?} {:#?} {:#?}",
+                delta.status(),
+                line.old_lineno().unwrap_or(0),
+                line.new_lineno().unwrap_or(0),
+                String::from_utf8(line.content().to_vec()).unwrap()
+            );
             true
         }),
-        None,
     )?;
+
+    if let Some(current_hunk) = &maybe_current_hunk {
+        ret.paths.insert(current_hunk.path.clone());
+        ret.hunks.push(current_hunk.clone());
+    }
 
     Ok(ret)
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -103,7 +103,6 @@ pub fn modified_since(upstream: &str) -> anyhow::Result<NewOrModified> {
                                             })
                                         });
                                 } else if let Some(current_hunk) = &maybe_current_hunk {
-                                    log::info!("Appending current hunk {:#?}", current_hunk);
                                     ret.paths.insert(current_hunk.path.clone());
                                     ret.hunks.push(current_hunk.clone());
                                     maybe_current_hunk = None;
@@ -119,13 +118,6 @@ pub fn modified_since(upstream: &str) -> anyhow::Result<NewOrModified> {
                     }
                 }
             }
-            log::info!(
-                "line_cb {:#?} {:#?} {:#?} {:#?}",
-                delta.status(),
-                line.old_lineno().unwrap_or(0),
-                line.new_lineno().unwrap_or(0),
-                String::from_utf8(line.content().to_vec()).unwrap()
-            );
             true
         }),
     )?;

--- a/src/rules/if_change_then_change.rs
+++ b/src/rules/if_change_then_change.rs
@@ -44,7 +44,7 @@ pub fn ictc(hunks: &Vec<Hunk>) -> anyhow::Result<Vec<diagnostic::Diagnostic>> {
             File::open(&h.path).with_context(|| format!("failed to open: {:#?}", h.path))?;
         let in_buf = BufReader::new(in_file);
         for (i, line) in lines_view(in_buf)
-            .context("failed to build lines view")?
+            .context(format!("failed to read lines of text from: {:#?}", h.path))?
             .iter()
             .enumerate()
             .map(|(i, line)| (i + 1, line))

--- a/src/rules/pls_no_land.rs
+++ b/src/rules/pls_no_land.rs
@@ -2,7 +2,6 @@ extern crate regex;
 
 use crate::diagnostic;
 use anyhow::Context;
-use content_inspector::inspect;
 use regex::Regex;
 use std::collections::HashSet;
 use std::fs::File;
@@ -33,7 +32,7 @@ fn pls_no_land_impl(path: &PathBuf) -> anyhow::Result<Vec<diagnostic::Diagnostic
     let mut first_line = vec![];
     in_buf.read_until(b'\n', &mut first_line)?;
 
-    if first_line.is_empty() || inspect(&first_line[..]).is_binary() {
+    if first_line.is_empty() {
         return Ok(vec![]);
     }
 

--- a/tests/if_change_then_change_test.rs
+++ b/tests/if_change_then_change_test.rs
@@ -1,0 +1,271 @@
+use spectral::prelude::*;
+
+mod integration_testing;
+use integration_testing::TestRepo;
+
+fn assert_no_expected_changes(revisions: [&str; 2]) -> anyhow::Result<()> {
+    let test_repo = TestRepo::make().unwrap();
+
+    test_repo.write(
+        "constant.foo",
+        "// IfChange\nlorem ipsum\nThenChange revision.foo".as_bytes(),
+    )?;
+    test_repo.write("revision.foo", revisions[0].as_bytes())?;
+    test_repo.git_commit_all("create constant.foo and revision.foo")?;
+
+    test_repo.write("revision.foo", revisions[1].as_bytes())?;
+    let horton = test_repo.run_horton()?;
+
+    assert_that(&horton.exit_code).contains_value(0);
+    assert_that(&horton.stdout.contains("Expected change")).is_false();
+    assert_that(&horton.stdout.contains("constant.foo")).is_false();
+    assert_that(&horton.stdout.contains("revision.foo")).is_false();
+
+    Ok(())
+}
+
+fn assert_expected_change_in_constant_foo(revisions: [&str; 2]) -> anyhow::Result<()> {
+    let test_repo = TestRepo::make().unwrap();
+
+    test_repo.write(
+        "constant.foo",
+        "// IfChange\nlorem ipsum\nThenChange revision.foo".as_bytes(),
+    )?;
+    test_repo.write("revision.foo", revisions[0].as_bytes())?;
+    test_repo.git_commit_all("create constant.foo and revision.foo")?;
+
+    test_repo.write("revision.foo", revisions[1].as_bytes())?;
+    let horton = test_repo.run_horton()?;
+
+    assert_that(&horton.exit_code).contains_value(0);
+    assert_that(&horton.stdout)
+        .contains("Expected change in constant.foo because revision.foo was modified");
+
+    Ok(())
+}
+
+#[test]
+fn unmodified_block_and_preceding_lines_unchanged() -> anyhow::Result<()> {
+    let revisions = [
+        r#"
+initial
+preceding
+lines
+// IfChange
+delta = "initial value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+        r#"
+initial
+preceding
+lines
+// IfChange
+delta = "initial value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+    ];
+
+    assert_no_expected_changes(revisions)
+}
+
+#[test]
+fn modified_block_and_preceding_lines_unchanged() -> anyhow::Result<()> {
+    let revisions = [
+        r#"
+initial
+preceding
+lines
+// IfChange
+delta = "initial value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+        r#"
+initial
+preceding
+lines
+// IfChange
+delta = "new value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+    ];
+
+    assert_expected_change_in_constant_foo(revisions)
+}
+
+#[test]
+fn unmodified_block_and_preceding_line_count_unchanged() -> anyhow::Result<()> {
+    let revisions = [
+        r#"
+initial
+preceding
+lines
+// IfChange
+delta = "initial value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+        r#"
+preceding lines
+have been changed
+but same number of them
+// IfChange
+delta = "initial value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+    ];
+
+    assert_no_expected_changes(revisions)
+}
+
+#[test]
+fn modified_block_and_preceding_line_count_unchanged() -> anyhow::Result<()> {
+    let revisions = [
+        r#"
+initial
+preceding
+lines
+// IfChange
+delta = "initial value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+        r#"
+preceding lines
+have been changed
+but same number of them
+// IfChange
+delta = "new value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+    ];
+
+    assert_expected_change_in_constant_foo(revisions)
+}
+
+#[test]
+fn unmodified_block_and_preceding_line_count_decreased() -> anyhow::Result<()> {
+    let revisions = [
+        r#"
+initial
+preceding
+lines
+// IfChange
+delta = "initial value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+        r#"
+fewer preceding lines
+// IfChange
+delta = "initial value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+    ];
+
+    assert_no_expected_changes(revisions)
+}
+
+#[test]
+fn modified_block_and_preceding_line_count_decreased() -> anyhow::Result<()> {
+    let revisions = [
+        r#"
+initial
+preceding
+lines
+// IfChange
+delta = "initial value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+        r#"
+fewer preceding lines
+// IfChange
+delta = "new value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+    ];
+
+    assert_expected_change_in_constant_foo(revisions)
+}
+
+#[test]
+fn unmodified_block_and_preceding_line_count_increased() -> anyhow::Result<()> {
+    let revisions = [
+        r#"
+initial
+preceding
+lines
+// IfChange
+delta = "initial value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+        r#"
+now
+there
+are
+more
+preceding
+lines
+// IfChange
+delta = "initial value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+    ];
+
+    assert_no_expected_changes(revisions)
+}
+
+#[test]
+fn modified_block_and_preceding_line_count_increased() -> anyhow::Result<()> {
+    let revisions = [
+        r#"
+initial
+preceding
+lines
+// IfChange
+delta = "initial value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+        r#"
+now
+there
+are
+more
+preceding
+lines
+// IfChange
+delta = "new value"
+// ThenChange constant.foo
+and then
+trailing lines
+"#,
+    ];
+
+    assert_expected_change_in_constant_foo(revisions)
+}

--- a/tests/main_test.rs
+++ b/tests/main_test.rs
@@ -1,0 +1,77 @@
+use spectral::prelude::*;
+
+mod integration_testing;
+use integration_testing::TestRepo;
+
+#[test]
+fn binary_file_untracked() -> anyhow::Result<()> {
+    let test_repo = TestRepo::make()?;
+
+    test_repo.write("picture.binary", include_bytes!("trunk-logo.png"))?;
+
+    let horton = test_repo.run_horton()?;
+
+    assert_that(&horton.exit_code).contains_value(0);
+    assert_that(&horton.stdout.contains("Expected change")).is_false();
+    assert_that(&horton.stdout.contains("picture.binary")).is_false();
+
+    Ok(())
+}
+
+#[test]
+fn binary_file_committed() -> anyhow::Result<()> {
+    let test_repo = TestRepo::make()?;
+
+    test_repo.write("picture.binary", include_bytes!("trunk-logo.png"))?;
+    test_repo.git_commit_all("commit a picture")?;
+
+    let horton = test_repo.run_horton_against("HEAD^")?;
+
+    assert_that(&horton.exit_code).contains_value(0);
+    assert_that(&horton.stdout.contains("Expected change")).is_false();
+    assert_that(&horton.stdout.contains("picture.binary")).is_false();
+
+    Ok(())
+}
+
+#[test]
+fn lfs_file_untracked() -> anyhow::Result<()> {
+    let test_repo = TestRepo::make()?;
+
+    test_repo.write(
+        ".gitattributes",
+        "*.binary filter=lfs diff=lfs merge=lfs -text\n".as_bytes(),
+    )?;
+    test_repo.git_commit_all("create .gitattributes")?;
+
+    test_repo.write("picture.binary", include_bytes!("trunk-logo.png"))?;
+
+    let horton = test_repo.run_horton()?;
+
+    assert_that(&horton.exit_code).contains_value(0);
+    assert_that(&horton.stdout.contains("Expected change")).is_false();
+    assert_that(&horton.stdout.contains("picture.binary")).is_false();
+
+    Ok(())
+}
+
+#[test]
+fn lfs_file_committed() -> anyhow::Result<()> {
+    let test_repo = TestRepo::make()?;
+
+    test_repo.write(
+        ".gitattributes",
+        "*.binary filter=lfs diff=lfs merge=lfs -text\n".as_bytes(),
+    )?;
+    test_repo.git_commit_all("create .gitattributes")?;
+
+    test_repo.write("picture.binary", include_bytes!("trunk-logo.png"))?;
+
+    let horton = test_repo.run_horton_against("HEAD^")?;
+
+    assert_that(&horton.exit_code).contains_value(0);
+    assert_that(&horton.stdout.contains("Expected change")).is_false();
+    assert_that(&horton.stdout.contains("picture.binary")).is_false();
+
+    Ok(())
+}


### PR DESCRIPTION
Teach if-change-then-change to respect moved if-change-then-change blocks and LFS.

  * Previously, we asked libgit2 for the hunks and blindly forwarded them to ICTC as the new&modified line ranges in a file. This is problematic because if lines are added before an ICTC block, libgit2 will say that the ICTC block moved, because its line numbers changed, even though its contents didn't change. As an example, let's say the contents of `foo.file` change from this

    ```
    1   alpha
    2   beta gamma
    3   // IfChange
    4   block contents
    5   // ThenChange other.file
    ```

    to this

    ```
    1   alpha
    2   beta
    3   gamma
    4   // IfChange
    5   block contents
    6   // ThenChange other.file
    ```

    The `DiffHunk` that libgit2 returns will span old lines 2 through 5 and new lines 2 through 6, even though the contents of the ICTC block haven't changed.

    To handle this case - which is honestly a pretty basic case - we instead construct our own hunks using the line-by-line diff that libgit2 hands back to us, which exclude lines whose contents have not changed between the upstream and current, even if their line numbers have changed.

  * We also add handling for LFS files. Today, toolbox errors out when it is presented with a diff that includes an LFS file, because it tries to parse the LFS file as a UTF-8 text file.

    This doesn't happen when just handling normal binary files, because when we use libgit2 to enumerate the set of files to lint, we rely on libgit2 to exclude binary files. Git itself, however, does not recognize LFS files as binary files - it thinks of them as text files whose attributes specify that Git should access using the LFS driver.

    To fix this, we just teach toolbox to check the attributes of every file in the diff, and to exclude files with a filter=lfs git attribute. (We could also use diff=lfs; there's no particular reason to choose one over another.)

We also make the following changes as well:

  * Add test coverage for if-change-then-change
  * Start using fluent test assertions via `spectral`, so that error messages in failing tests are actually informative about what's failing
  * Stop using content_inspector to filter out binary files, since the new LFS handling logic applies at file set resolution time.
  * Support arbitrary revspecs (e.g. `HEAD^`, which is not a valid reference, or hash prefixes) for `--upstream`, by going through `revparse_single`