### PR TITLE
fix: anchor the regex used for ictc

### DIFF
--- a/src/rules/if_change_then_change.rs
+++ b/src/rules/if_change_then_change.rs
@@ -19,8 +19,8 @@ pub struct IctcBlock {
 }
 
 lazy_static::lazy_static! {
-    static ref RE_BEGIN: Regex = Regex::new(r"(?i) *(//|#) *ifchange").unwrap();
-    static ref RE_END: Regex = Regex::new(r"(?i) *(//|#) *thenchange (.*)").unwrap();
+    static ref RE_BEGIN: Regex = Regex::new(r"(?i)^ *(//|#) *ifchange *$").unwrap();
+    static ref RE_END: Regex = Regex::new(r"(?i)^ *(//|#) *thenchange *(.*)$").unwrap();
 
 }
 

--- a/src/rules/if_change_then_change.rs
+++ b/src/rules/if_change_then_change.rs
@@ -19,8 +19,8 @@ pub struct IctcBlock {
 }
 
 lazy_static::lazy_static! {
-    static ref RE_BEGIN: Regex = Regex::new(r"(?i)^ *(//|#) *ifchange *$").unwrap();
-    static ref RE_END: Regex = Regex::new(r"(?i)^ *(//|#) *thenchange *(.*)$").unwrap();
+    static ref RE_BEGIN: Regex = Regex::new(r"(?i)^\s*(//|#)\s*ifchange\s*$").unwrap();
+    static ref RE_END: Regex = Regex::new(r"(?i)^\s*(//|#)\s*thenchange\s*(.*)$").unwrap();
 
 }
 

--- a/src/rules/if_change_then_change.rs
+++ b/src/rules/if_change_then_change.rs
@@ -19,8 +19,8 @@ pub struct IctcBlock {
 }
 
 lazy_static::lazy_static! {
-    static ref RE_BEGIN: Regex = Regex::new(r"(?i)^ *?(//|#) *?ifchange *?$").unwrap();
-    static ref RE_END: Regex = Regex::new(r"(?i)^ *?(//|#) *?thenchange *?(.*?)$").unwrap();
+    static ref RE_BEGIN: Regex = Regex::new(r"(?i)^ *(//|#) *ifchange *$").unwrap();
+    static ref RE_END: Regex = Regex::new(r"(?i)^ *(//|#) *thenchange *(.*)$").unwrap();
 
 }
 

--- a/src/rules/if_change_then_change.rs
+++ b/src/rules/if_change_then_change.rs
@@ -19,8 +19,8 @@ pub struct IctcBlock {
 }
 
 lazy_static::lazy_static! {
-    static ref RE_BEGIN: Regex = Regex::new(r"(?i)^ *(//|#) *ifchange *$").unwrap();
-    static ref RE_END: Regex = Regex::new(r"(?i)^ *(//|#) *thenchange *(.*)$").unwrap();
+    static ref RE_BEGIN: Regex = Regex::new(r"(?i)^ *?(//|#) *?ifchange *?$").unwrap();
+    static ref RE_END: Regex = Regex::new(r"(?i)^ *?(//|#) *?thenchange *?(.*?)$").unwrap();
 
 }
 


### PR DESCRIPTION
Rust's regex crate does not have a notion of `regex.match`; it instead just provides `regex.find` and requires that you anchor your regex yourself, [discussion](https://github.com/rust-lang/regex/discussions/737).

This is more a correctness fix than a performance fix.