### PR TITLE
[ictc] Only scan each file once

### DIFF
--- a/src/rules/if_change_then_change.rs
+++ b/src/rules/if_change_then_change.rs
@@ -37,14 +37,15 @@ pub fn ictc(hunks: &Vec<Hunk>) -> anyhow::Result<Vec<diagnostic::Diagnostic>> {
     let modified_lines_by_path = modified_lines_by_path;
 
     let mut blocks: Vec<IctcBlock> = Vec::new();
-    for h in hunks {
+    for path in modified_lines_by_path.keys() {
         let mut ifttt_begin: i64 = -1;
 
         let in_file =
-            File::open(&h.path).with_context(|| format!("failed to open: {:#?}", h.path))?;
+            File::open(&path).with_context(|| format!("failed to open: {:#?}", path))?;
         let in_buf = BufReader::new(in_file);
+
         for (i, line) in lines_view(in_buf)
-            .context(format!("failed to read lines of text from: {:#?}", h.path))?
+            .context(format!("failed to read lines of text from: {:#?}", path))?
             .iter()
             .enumerate()
             .map(|(i, line)| (i + 1, line))
@@ -54,7 +55,7 @@ pub fn ictc(hunks: &Vec<Hunk>) -> anyhow::Result<Vec<diagnostic::Diagnostic>> {
             } else if let Some(end) = RE_END.captures(line) {
                 if ifttt_begin != -1 {
                     let block = IctcBlock {
-                        path: h.path.clone(),
+                        path: path.clone(),
                         begin: ifttt_begin,
                         end: i as i64,
                         thenchange: PathBuf::from(end.get(2).unwrap().as_str()),

--- a/src/rules/if_change_then_change.rs
+++ b/src/rules/if_change_then_change.rs
@@ -40,8 +40,7 @@ pub fn ictc(hunks: &Vec<Hunk>) -> anyhow::Result<Vec<diagnostic::Diagnostic>> {
     for path in modified_lines_by_path.keys() {
         let mut ifttt_begin: i64 = -1;
 
-        let in_file =
-            File::open(&path).with_context(|| format!("failed to open: {:#?}", path))?;
+        let in_file = File::open(&path).with_context(|| format!("failed to open: {:#?}", path))?;
         let in_buf = BufReader::new(in_file);
 
         for (i, line) in lines_view(in_buf)


### PR DESCRIPTION
Previously, `ictc` looped over each hunk and reopened, scanned, and closed the same file multiple times. However, since we already computed which lines are changed, we should be able to get away with only going through each file once and checking if any of the ictc regions' line numbers overlap with the set of lines changed in that file