### PR TITLE
fix: build linux release for old glibc

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runs-on: ubuntu-latest
             container: ubuntu:14.04
-            setup: apt-cache search curl; apt-get install curl
+            setup: apt-get install curl --yes
           - target: x86_64-unknown-linux-musl
             runs-on: ubuntu-latest
           - target: x86_64-apple-darwin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runs-on: ubuntu-latest
             container: ubuntu:14.04
-            setup: apt-get search curl; apt-get install curl
+            setup: apt-cache search curl; apt-get install curl
           - target: x86_64-unknown-linux-musl
             runs-on: ubuntu-latest
           - target: x86_64-apple-darwin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,6 @@ jobs:
           - target: aarch64-apple-darwin
             runs-on: macos-latest
     runs-on: ${{ matrix.runs-on }}
-    container: ${{ matrix.container }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install prereqs
-        if: matrix.container == "ubuntu:16.04"
+        if: matrix.container == 'ubuntu:16.04'
         run: apt search curl; apt install curl
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,8 @@ jobs:
           - target: aarch64-apple-darwin
             runs-on: macos-latest
     runs-on: ${{ matrix.runs-on }}
+    container: ${{ matrix.container }}
+
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,9 +29,6 @@ jobs:
       - name: Set up toolchains
         run: rustup target add ${{ matrix.target }}
 
-      - name: Dump glibc version
-        run: ldd --version
-
       - name: Build --release
         run: cargo build --release --target ${{ matrix.target }}
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runs-on: ubuntu-latest
             container: ubuntu:18.04
+            setup: apt search curl; apt install curl
           - target: x86_64-apple-darwin
             runs-on: macos-latest
           - target: aarch64-apple-darwin
@@ -24,11 +25,10 @@ jobs:
     container: ${{ matrix.container }}
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Setup
+        run: ${{ matrix.setup }}
 
-      - name: Install prereqs
-        if: matrix.container == 'ubuntu:16.04'
-        run: apt search curl; apt install curl
+      - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,8 +27,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install prereqs
-        if: ${{ matrix.container }} == "ubuntu:16.04"
-        run: apt install curl
+        if: matrix.container == "ubuntu:16.04"
+        run: apt search curl; apt install curl
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
           - target: x86_64-unknown-linux-musl
             runs-on: ubuntu-latest
             container: ubuntu
-            setup: apt install musl-tools
+            setup: apt install curl musl-tools
           - target: x86_64-apple-darwin
             runs-on: macos-latest
           - target: aarch64-apple-darwin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             runs-on: ubuntu-latest
+            container: ubuntu:14.04
           - target: x86_64-apple-darwin
             runs-on: macos-latest
           - target: aarch64-apple-darwin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,14 +14,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            # NOTE(sam): target ubuntu 14 for maximum backwards glibc compatibility, since it's
-            # listed on https://hub.docker.com/_/ubuntu as a supported tag. If this ever takes
-            # more than 10 min to fix an issue, we should just try to use ubuntu-18.04 (or whatever
-            # the oldest Linux image that GH Actions supports is, see
-            # https://github.com/actions/runner-images#available-images).
-            runs-on: ubuntu-latest
-            container: ubuntu:14.04
-            setup: apt-get install curl --yes
+            runs-on: ubuntu-18.04
           - target: x86_64-unknown-linux-musl
             runs-on: ubuntu-latest
           - target: x86_64-apple-darwin
@@ -32,9 +25,6 @@ jobs:
     container: ${{ matrix.container }}
 
     steps:
-      - name: Setup
-        run: ${{ matrix.setup }}
-
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             runs-on: ubuntu-latest
-            container: ubuntu:14.04
+            container: ubuntu:16.04
           - target: x86_64-apple-darwin
             runs-on: macos-latest
           - target: aarch64-apple-darwin
@@ -25,6 +25,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install prereqs
+        if: ${{ matrix.container }} == "ubuntu:16.04"
+        run: apt install curl
+
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Set up toolchains

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,9 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            runs-on: ubuntu-18.04
+            runs-on: ubuntu-latest
+            container: ubuntu:14.04
+            setup: apt-get search curl; apt-get install curl
           - target: x86_64-unknown-linux-musl
             runs-on: ubuntu-latest
           - target: x86_64-apple-darwin
@@ -22,8 +24,12 @@ jobs:
           - target: aarch64-apple-darwin
             runs-on: macos-latest
     runs-on: ${{ matrix.runs-on }}
+    container: ${{ matrix.container }}
 
     steps:
+      - name: Setup
+        run: ${{ matrix.setup }}
+
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
             runs-on: ubuntu-18.04
           - target: x86_64-unknown-linux-musl
             runs-on: ubuntu-latest
-            container: ubuntu
+            container: ubuntu:latest
             setup: apt install curl musl-tools
           - target: x86_64-apple-darwin
             runs-on: macos-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,9 +14,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            runs-on: ubuntu-latest
-            container: ubuntu:18.04
-            setup: apt search curl; apt install curl
+            runs-on: ubuntu-18.04
           - target: x86_64-apple-darwin
             runs-on: macos-latest
           - target: aarch64-apple-darwin
@@ -25,9 +23,6 @@ jobs:
     container: ${{ matrix.container }}
 
     steps:
-      - name: Setup
-        run: ${{ matrix.setup }}
-
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,14 +17,18 @@ jobs:
             runs-on: ubuntu-18.04
           - target: x86_64-unknown-linux-musl
             runs-on: ubuntu-latest
+            setup: apt install musl-tools
           - target: x86_64-apple-darwin
             runs-on: macos-latest
           - target: aarch64-apple-darwin
             runs-on: macos-latest
     runs-on: ${{ matrix.runs-on }}
-    container: ${{ matrix.container }}
 
     steps:
+      - name: Setup
+        if: ${{ matrix.setup }}
+        run: ${{ matrix.setup }}
+
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Set up toolchains
         run: rustup target add ${{ matrix.target }}
 
+      - name: Dump glibc version
+        run: ldd --version
+
       - name: Build --release
         run: cargo build --release --target ${{ matrix.target }}
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             runs-on: ubuntu-latest
-            container: ubuntu:16.04
+            container: ubuntu:18.04
           - target: x86_64-apple-darwin
             runs-on: macos-latest
           - target: aarch64-apple-darwin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,10 +15,6 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             runs-on: ubuntu-18.04
-          - target: x86_64-unknown-linux-musl
-            runs-on: ubuntu-latest
-            container: ubuntu:latest
-            setup: apt install curl musl-tools
           - target: x86_64-apple-darwin
             runs-on: macos-latest
           - target: aarch64-apple-darwin
@@ -27,10 +23,6 @@ jobs:
     container: ${{ matrix.container }}
 
     steps:
-      - name: Setup
-        if: ${{ matrix.setup }}
-        run: ${{ matrix.setup }}
-
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,12 +17,14 @@ jobs:
             runs-on: ubuntu-18.04
           - target: x86_64-unknown-linux-musl
             runs-on: ubuntu-latest
+            container: ubuntu
             setup: apt install musl-tools
           - target: x86_64-apple-darwin
             runs-on: macos-latest
           - target: aarch64-apple-darwin
             runs-on: macos-latest
     runs-on: ${{ matrix.runs-on }}
+    container: ${{ matrix.container }}
 
     steps:
       - name: Setup

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,11 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
+            # NOTE(sam): target ubuntu 14 for maximum backwards glibc compatibility, since it's
+            # listed on https://hub.docker.com/_/ubuntu as a supported tag. If this ever takes
+            # more than 10 min to fix an issue, we should just try to use ubuntu-18.04 (or whatever
+            # the oldest Linux image that GH Actions supports is, see
+            # https://github.com/actions/runner-images#available-images).
             runs-on: ubuntu-latest
             container: ubuntu:14.04
             setup: apt-get install curl --yes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,8 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             runs-on: ubuntu-18.04
+          - target: x86_64-unknown-linux-musl
+            runs-on: ubuntu-latest
           - target: x86_64-apple-darwin
             runs-on: macos-latest
           - target: aarch64-apple-darwin


### PR DESCRIPTION
`x86_64-unknown-linux-gnu` builds target the _host_ glibc, not the target glibc, which means that when we run on ubuntu-latest we end up building for a pretty recent glibc. This causes errors like:

    toolbox: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by toolbox)
    toolbox: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by toolbox)
    toolbox: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by toolbox)

To grab an old glibc, we use the oldest version of Ubuntu available for GitHub Actions and hope that that's old enough.

Also set up a musl build, which _is_ statically linked - i.e. the only things left to the runtime are the Linux ABI.

We tried using `container: ubuntu:14.04` ([see related blog post](https://kobzol.github.io/rust/ci/2021/05/07/building-rust-binaries-in-ci-that-work-with-older-glibc.html)), but the `curl` available in 14.04 is too old for `dtolnay/rust-toolchain`.