### PR TITLE
Add new TODO rule

### DIFF
--- a/.config/toolbox.toml
+++ b/.config/toolbox.toml
@@ -5,3 +5,6 @@ enabled = true
 
 [donotland]
 enabled = true
+
+[todo]
+enabled = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Trunk toolbox is a place for rules that transcend particular languages and are r
 
 ## Development
 
-The trunk.yaml in this repo has been modified to run your local iteration of toolbox as you are building. This is managed through the `trunk-latest` script. Effectively as you run `cargo build` or `cargo build release` the script will pick up the last built binary and use that.
+The trunk.yaml in this repo has been modified to run your local iteration of toolbox as you are building. This is managed through the `toolbox-latest` script. Effectively as you run `cargo build` or `cargo build release` the script will pick up the last built binary and use that.
 
 If no local binary has been built then the pinned version in the trunk.yaml will be used.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 Toolbox is our custom collection of must have tools for any large software project. We've got a backlog of small tools to built into our toolbox here and happy to take contributions as well. `toolbox` is best used through `trunk check` to keep your development on rails (not the ruby kind).
 
 This repo is open to contributions! See our
-[contribution guidelines](https://github.com/trunk-io/toolbox/blob/main/CONTRIBUTING.md)
+[contribution guidelines](CONTRIBUTING.md)
 
 ### Enabling
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,32 @@ Anything you intentionally don't want in your repo should really not be there. T
 console.log("I don't think this code should execute");
 ```
 
+#### TODO
+
+##### What it does
+
+Keeps you from accidentally commiting incomplete code to your repo. This is functionally the same as DONOTLAND, but reports at a lower severity so you can customize your approach to burning them down.
+
+Valid triggers for this rule are: TODO, todo, FIXME, fixme
+
+By default, this rule is disabled and must be enabled with:
+
+```toml
+[todo]
+enabled = true
+```
+
+##### Why if this bad?
+
+TODOs should be treated like any other lint issue. Sometimes you need to land code that still has these issues, but you want to keep track of them and avoid them when possible.
+
+##### Example
+
+```typescript
+// TODO: We should evaluate using the asynchronous API
+uploadResultsSync();
+```
+
 #### if-change-then-change
 
 ##### What it does

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-// trunk-ignore-all(trunk-toolbox/do-not-land)
+// trunk-ignore-all(trunk-toolbox/do-not-land,trunk-toolbox/todo)
 use confique::toml::{self, FormatOptions};
 use confique::Config;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,9 @@ pub struct Conf {
 
     #[config(nested)]
     pub donotland: PlsNotLandConf,
+
+    #[config(nested)]
+    pub todo: TodoConf,
 }
 
 impl Conf {
@@ -27,5 +30,11 @@ pub struct IfChangeConf {
 #[derive(Config)]
 pub struct PlsNotLandConf {
     #[config(default = true)]
+    pub enabled: bool,
+}
+
+#[derive(Config)]
+pub struct TodoConf {
+    #[config(default = false)]
     pub enabled: bool,
 }

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -1,11 +1,23 @@
 use serde::Serialize;
+use std::fmt;
 
 #[derive(Serialize)]
 pub enum Severity {
     Error,
     Warning,
-    Information,
-    Hint,
+    Note,
+    None,
+}
+
+impl fmt::Display for Severity {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Severity::Error => write!(f, "error"),
+            Severity::Warning => write!(f, "warning"),
+            Severity::Note => write!(f, "note"),
+            Severity::None => write!(f, "none"),
+        }
+    }
 }
 
 #[derive(Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn run() -> anyhow::Result<()> {
         .iter()
         .map(|d| {
             sarif::ResultBuilder::default()
-                .level("error")
+                .level(d.severity.to_string())
                 .locations([sarif::LocationBuilder::default()
                     .physical_location(
                         sarif::PhysicalLocationBuilder::default()
@@ -105,7 +105,7 @@ fn run() -> anyhow::Result<()> {
                 .unwrap(),
         )
         .rule_id("toolbox-perf")
-        .level("note")
+        .level(diagnostic::Severity::Note.to_string())
         .build()
         .unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ fn run() -> anyhow::Result<()> {
         .file("toolbox.toml")
         .file(".config/toolbox.toml")
         .file(".trunk/config/toolbox.toml")
+        .file(".trunk/configs/toolbox.toml")
         .load()
         .unwrap_or_else(|err| {
             eprintln!("Toolbox cannot run: {}", err);

--- a/src/rules/pls_no_land.rs
+++ b/src/rules/pls_no_land.rs
@@ -128,7 +128,8 @@ fn pls_no_land_impl(path: &PathBuf, config: &Conf) -> anyhow::Result<Vec<diagnos
                             character: m.get(1).unwrap().end() as u64,
                         },
                     },
-                    severity: diagnostic::Severity::Error,
+                    // Lower severity than DNL
+                    severity: diagnostic::Severity::Warning,
                     code: "todo".to_string(),
                     message: format!("Found '{}'", token),
                 });

--- a/tests/todo_test.rs
+++ b/tests/todo_test.rs
@@ -1,0 +1,85 @@
+// trunk-ignore-all(trunk-toolbox/todo)
+use spectral::prelude::*;
+
+mod integration_testing;
+use integration_testing::TestRepo;
+
+fn write_enable_config(test_repo: &TestRepo) -> anyhow::Result<()> {
+    let config = r#"
+    [todo]
+    enabled = true
+
+    [donotland]
+    enabled = false
+"#;
+    test_repo.write("toolbox.toml", config.as_bytes());
+    Ok(())
+}
+
+#[test]
+fn basic_todo() -> anyhow::Result<()> {
+    let test_repo = TestRepo::make()?;
+
+    test_repo.write(
+        "alpha.foo",
+        "lorem ipsum dolor\ntoDO\nsit amet\n".as_bytes(),
+    );
+    write_enable_config(&test_repo);
+    test_repo.git_add_all()?;
+    let horton = test_repo.run_horton()?;
+
+    assert_that(&horton.exit_code).contains_value(0);
+    assert_that(&horton.stdout).contains("Found 'toDO'");
+
+    Ok(())
+}
+
+#[test]
+fn basic_fixme() -> anyhow::Result<()> {
+    let test_repo = TestRepo::make()?;
+
+    test_repo.write(
+        "alpha.foo",
+        "lorem ipsum dolor\nFIXME: fix this\nsit amet\n".as_bytes(),
+    );
+    write_enable_config(&test_repo);
+    test_repo.git_add_all()?;
+    let horton = test_repo.run_horton()?;
+
+    assert_that(&horton.exit_code).contains_value(0);
+    assert_that(&horton.stdout).contains("Found 'FIXME'");
+
+    Ok(())
+}
+
+#[test]
+fn basic_mastodon() -> anyhow::Result<()> {
+    let test_repo = TestRepo::make()?;
+
+    test_repo.write(
+        "alpha.foo",
+        "lorem ipsum dolor\n// Mastodons are cool\nsit amet\n".as_bytes(),
+    );
+    write_enable_config(&test_repo);
+    test_repo.git_add_all()?;
+    let horton = test_repo.run_horton()?;
+
+    assert_that(&horton.exit_code).contains_value(0);
+    assert_that(&horton.stdout.contains("Found 'todo'")).is_false();
+
+    Ok(())
+}
+
+#[test]
+fn default_disabled_in_config() -> anyhow::Result<()> {
+    let test_repo = TestRepo::make()?;
+    test_repo.write("alpha.foo", "todo\n".as_bytes());
+    test_repo.git_add_all()?;
+
+    {
+        let horton = test_repo.run_horton()?;
+        assert_that(&horton.stdout.contains("Found 'todo'")).is_false();
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Adds a rule (default disabled) that checks for TODOs and FIXMEs. This is very similar to DO_NOT_LAND but outputs at a lower severity and default config disabled.

The intention is for this to be our OOTB solution for a TODO linter (as compared with per-language linter plugins and abusing linting spellcheckers). I merged most of the logic with DNL so that we wouldn't have to read through files twice.