### PR TITLE
Support a human readable output format

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,12 @@ fn generate_line_string(original_results: &diagnostic::Diagnostics) -> String {
         .iter()
         .map(|d| {
             format!(
-                "{}:{}:{}: {}",
-                d.range.path, d.range.start.line, d.range.start.character, d.message
+                "{}:{}:{}: {} ({})",
+                d.range.path,
+                d.range.start.line,
+                d.range.start.character,
+                d.message,
+                d.severity.to_string()
             )
         })
         .collect::<Vec<String>>()

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,10 @@ fn generate_line_string(original_results: &diagnostic::Diagnostics) -> String {
         .diagnostics
         .iter()
         .map(|d| {
-            return format!(
+            format!(
                 "{}:{}:{}: {}",
                 d.range.path, d.range.start.line, d.range.start.character, d.message
-            );
+            )
         })
         .collect::<Vec<String>>()
         .join("\n");
@@ -109,7 +109,7 @@ fn generate_sarif_string(
         .build()?;
 
     let sarif = serde_json::to_string_pretty(&sarif_built)?;
-    return Ok(sarif);
+    Ok(sarif)
 }
 
 fn run() -> anyhow::Result<()> {
@@ -153,11 +153,9 @@ fn run() -> anyhow::Result<()> {
         Err(e) => return Err(e),
     }
 
-    let output_string;
+    let mut output_string = generate_line_string(&ret);
     if cli.output_format == OutputFormat::Sarif {
         output_string = generate_sarif_string(&ret, &run, &start)?;
-    } else {
-        output_string = generate_line_string(&ret);
     }
 
     if let Some(outfile) = &cli.results {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,11 +17,7 @@ fn generate_line_string(original_results: &diagnostic::Diagnostics) -> String {
         .map(|d| {
             format!(
                 "{}:{}:{}: {} ({})",
-                d.range.path,
-                d.range.start.line,
-                d.range.start.character,
-                d.message,
-                d.severity.to_string()
+                d.range.path, d.range.start.line, d.range.start.character, d.message, d.severity
             )
         })
         .collect::<Vec<String>>()

--- a/src/run.rs
+++ b/src/run.rs
@@ -37,7 +37,6 @@ pub struct Cli {
     pub upstream: String,
 
     #[clap(long, default_value = "sarif")]
-    // #[arg(default_value_t = "sarif")]
     pub output_format: OutputFormat,
 
     #[clap(long)]

--- a/src/run.rs
+++ b/src/run.rs
@@ -2,7 +2,27 @@ use crate::config::Conf;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
+use clap::builder::PossibleValue;
+use clap::{Parser, Subcommand, ValueEnum};
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum OutputFormat {
+    Sarif,
+    Text,
+}
+
+impl ValueEnum for OutputFormat {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::Sarif, Self::Text]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(match self {
+            Self::Sarif => PossibleValue::new("sarif"),
+            Self::Text => PossibleValue::new("text"),
+        })
+    }
+}
 
 #[derive(Parser, Debug)]
 #[clap(version = env!("CARGO_PKG_VERSION"), author = "Trunk Technologies Inc.")]
@@ -15,6 +35,10 @@ pub struct Cli {
     #[clap(long)]
     #[arg(default_value_t = String::from("HEAD"))]
     pub upstream: String,
+
+    #[clap(long, default_value = "sarif")]
+    // #[arg(default_value_t = "sarif")]
+    pub output_format: OutputFormat,
 
     #[clap(long)]
     /// optional path to write results to

--- a/tests/integration_testing.rs
+++ b/tests/integration_testing.rs
@@ -115,10 +115,14 @@ impl TestRepo {
     }
 
     pub fn run_horton(&self) -> anyhow::Result<HortonOutput> {
-        self.run_horton_against("HEAD")
+        self.run_horton_with("HEAD", "sarif")
     }
 
-    pub fn run_horton_against(&self, upstream_ref: &str) -> anyhow::Result<HortonOutput> {
+    pub fn run_horton_with(
+        &self,
+        upstream_ref: &str,
+        format: &str,
+    ) -> anyhow::Result<HortonOutput> {
         let mut cmd = Command::cargo_bin("trunk-toolbox")?;
 
         let modified_paths =
@@ -132,6 +136,7 @@ impl TestRepo {
         cmd.arg("--upstream")
             .arg(upstream_ref)
             .current_dir(self.dir.path());
+        cmd.arg("--output-format").arg(format);
         for path in strings.unwrap() {
             cmd.arg(path);
         }

--- a/tests/main_test.rs
+++ b/tests/main_test.rs
@@ -25,7 +25,7 @@ fn binary_file_committed() -> anyhow::Result<()> {
     test_repo.write("picture.binary", include_bytes!("trunk-logo.png"));
     test_repo.git_commit_all("commit a picture");
 
-    let horton = test_repo.run_horton_against("HEAD^")?;
+    let horton = test_repo.run_horton_with("HEAD^", "sarif")?;
 
     assert_that(&horton.exit_code).contains_value(0);
     assert_that(&horton.stdout.contains("Expected change")).is_false();
@@ -67,7 +67,7 @@ fn lfs_file_committed() -> anyhow::Result<()> {
 
     test_repo.write("picture.binary", include_bytes!("trunk-logo.png"));
 
-    let horton = test_repo.run_horton_against("HEAD^")?;
+    let horton = test_repo.run_horton_with("HEAD^", "sarif")?;
 
     assert_that(&horton.exit_code).contains_value(0);
     assert_that(&horton.stdout.contains("Expected change")).is_false();

--- a/tests/output.sarif
+++ b/tests/output.sarif
@@ -1,0 +1,65 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "alpha.foo"
+                },
+                "region": {
+                  "endColumn": 12,
+                  "endLine": 2,
+                  "startColumn": 1,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Found 'do-NOT-lAnD'"
+          },
+          "ruleId": "do-not-land"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "alpha.foo"
+                },
+                "region": {
+                  "endColumn": 10,
+                  "endLine": 3,
+                  "startColumn": 1,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Found 'DONOTLAND'"
+          },
+          "ruleId": "do-not-land"
+        },
+        {
+          "level": "note",
+          "message": {
+            "text": "1 files processed in ms"
+          },
+          "ruleId": "toolbox-perf"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "name": "trunk-toolbox"
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/tests/output_format_test.rs
+++ b/tests/output_format_test.rs
@@ -42,8 +42,9 @@ fn default_print() -> anyhow::Result<()> {
     );
     test_repo.git_add_all()?;
     let horton = test_repo.run_horton_with("HEAD", "text")?;
-    let expected_text =
-        String::from("alpha.foo:1:0: Found 'do-NOT-lAnD'\nalpha.foo:2:0: Found 'DONOTLAND'\n");
+    let expected_text = String::from(
+        "alpha.foo:1:0: Found 'do-NOT-lAnD' (error)\nalpha.foo:2:0: Found 'DONOTLAND' (error)\n",
+    );
 
     assert_that(&horton.exit_code).contains_value(0);
     assert_that(&horton.stdout).is_equal_to(&expected_text);

--- a/tests/output_format_test.rs
+++ b/tests/output_format_test.rs
@@ -1,0 +1,53 @@
+// trunk-ignore-all(trunk-toolbox/do-not-land)
+extern crate regex;
+
+use spectral::prelude::*;
+use std::env;
+use std::fs;
+use std::path::Path;
+
+use regex::Regex;
+mod integration_testing;
+use integration_testing::TestRepo;
+
+#[test]
+fn default_sarif() -> anyhow::Result<()> {
+    let test_repo = TestRepo::make()?;
+
+    let mut expected_file = Path::new(file!()).parent().unwrap().join("output.sarif");
+    let expected_sarif = fs::read_to_string(expected_file)?;
+
+    test_repo.write(
+        "alpha.foo",
+        "lorem ipsum dolor\ndo-NOT-lAnD\nDONOTLAND sit amet\n".as_bytes(),
+    );
+    test_repo.git_add_all()?;
+    let horton = test_repo.run_horton()?;
+
+    let re = Regex::new(r"\d+\.\d+ms").unwrap();
+    let normalized_output = re.replace(&horton.stdout, "ms");
+
+    assert_that(&horton.exit_code).contains_value(0);
+    assert_that(&normalized_output.to_string()).is_equal_to(expected_sarif);
+
+    Ok(())
+}
+
+#[test]
+fn default_print() -> anyhow::Result<()> {
+    let test_repo = TestRepo::make()?;
+
+    test_repo.write(
+        "alpha.foo",
+        "lorem ipsum dolor\ndo-NOT-lAnD\nDONOTLAND sit amet\n".as_bytes(),
+    );
+    test_repo.git_add_all()?;
+    let horton = test_repo.run_horton_with("HEAD", "text")?;
+    let expected_text =
+        String::from("alpha.foo:1:0: Found 'do-NOT-lAnD'\nalpha.foo:2:0: Found 'DONOTLAND'\n");
+
+    assert_that(&horton.exit_code).contains_value(0);
+    assert_that(&horton.stdout).is_equal_to(&expected_text);
+
+    Ok(())
+}

--- a/tests/output_format_test.rs
+++ b/tests/output_format_test.rs
@@ -2,7 +2,6 @@
 extern crate regex;
 
 use spectral::prelude::*;
-use std::env;
 use std::fs;
 use std::path::Path;
 
@@ -14,7 +13,7 @@ use integration_testing::TestRepo;
 fn default_sarif() -> anyhow::Result<()> {
     let test_repo = TestRepo::make()?;
 
-    let mut expected_file = Path::new(file!()).parent().unwrap().join("output.sarif");
+    let expected_file = Path::new(file!()).parent().unwrap().join("output.sarif");
     let expected_sarif = fs::read_to_string(expected_file)?;
 
     test_repo.write(

--- a/tests/todo_test.rs
+++ b/tests/todo_test.rs
@@ -24,7 +24,7 @@ fn basic_todo() -> anyhow::Result<()> {
         "alpha.foo",
         "lorem ipsum dolor\ntoDO\nsit amet\n".as_bytes(),
     );
-    write_enable_config(&test_repo);
+    write_enable_config(&test_repo)?;
     test_repo.git_add_all()?;
     let horton = test_repo.run_horton()?;
 
@@ -42,7 +42,7 @@ fn basic_fixme() -> anyhow::Result<()> {
         "alpha.foo",
         "lorem ipsum dolor\nFIXME: fix this\nsit amet\n".as_bytes(),
     );
-    write_enable_config(&test_repo);
+    write_enable_config(&test_repo)?;
     test_repo.git_add_all()?;
     let horton = test_repo.run_horton()?;
 
@@ -60,7 +60,7 @@ fn basic_mastodon() -> anyhow::Result<()> {
         "alpha.foo",
         "lorem ipsum dolor\n// Mastodons are cool\nsit amet\n".as_bytes(),
     );
-    write_enable_config(&test_repo);
+    write_enable_config(&test_repo)?;
     test_repo.git_add_all()?;
     let horton = test_repo.run_horton()?;
 


### PR DESCRIPTION
Adds `--output-format=sarif|text` (default `sarif`) to allow us to produce more readable outputs. For now it's just `path:line:col msg (severity)`