### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,11 @@ jobs:
               -C build/${target} trunk-toolbox
           done
 
+      - name: Install gh binary
+        uses: trunk-io/trunk-action/install@v1
+        with:
+          tools: gh
+
       - name: Create GH release and upload binary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We moved onto different runners so we need to make sure `gh` is installed. Previous [failure](https://github.com/trunk-io/toolbox/actions/runs/9667815723/job/26670607023)