### PR TITLE
if-change rule should not run on upstream. it only cares about current changes

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -32,6 +32,7 @@ lint:
           batch: true
           success_codes: [0]
           read_output_from: tmp_file
+          cache_results: true
           disable_upstream: false
           max_concurrency: 1
           direct_configs: [toolbox.toml, log4rs.yaml]

--- a/src/rules/if_change_then_change.rs
+++ b/src/rules/if_change_then_change.rs
@@ -126,6 +126,11 @@ pub fn ictc(run: &Run, upstream: &str) -> anyhow::Result<Vec<diagnostic::Diagnos
         return Ok(vec![]);
     }
 
+    if run.is_upstream() {
+        trace!("'if-change' rule doesn't run on upstream");
+        return Ok(vec![]);
+    }
+
     debug!(
         "scanning {} files for if_change_then_change",
         run.paths.len()


### PR DESCRIPTION
1) if-change rule should not run on upstream. it only cares about current changes
2) enable caching of trunk-toolbox runs