### PR TITLE
(Chore): Upgrade and turn off auto-upgrade

### DIFF
--- a/.github/workflows/upgrade.yaml
+++ b/.github/workflows/upgrade.yaml
@@ -1,7 +1,7 @@
 name: Upgrade trunk
 on:
-  schedule:
-    - cron: 0 8 * * 1-5
+  # schedule:
+  #   - cron: 0 8 * * 1-5
   workflow_dispatch: {}
 permissions: read-all
 jobs:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,23 +1,22 @@
 version: 0.1
+cli:
+  version: 1.22.8
+api:
+  address: api.trunk-staging.io:8443
 plugins:
   sources:
     - id: trunk
-      ref: v1.6.3
+      ref: v1.6.6
       uri: https://github.com/trunk-io/plugins
 runtimes:
   enabled:
     - python@3.10.8
     - go@1.21.0
-    - node@18.12.1
-    - rust@1.76.0
-cli:
-  version: 1.22.6
-api:
-  address: api.trunk-staging.io:8443
-
+    - node@18.20.5
+    - rust@1.82.0
 tools:
   enabled:
-    - gh@2.58.0
+    - gh@2.65.0
   runtimes:
     - rust
 lint:
@@ -53,21 +52,21 @@ lint:
         - tests/**
 
   enabled:
-    - osv-scanner@1.9.0
+    - osv-scanner@1.9.2
     - shellcheck@0.10.0
     - shfmt@3.6.0
-    - trunk-toolbox@0.3.2
-    - checkov@3.2.238
-    - trufflehog@3.81.9
-    - oxipng@9.1.2
+    - trunk-toolbox@0.5.4
+    - checkov@3.2.347
+    - trufflehog@3.88.1
+    - oxipng@9.1.3
     - yamllint@1.35.1
     - git-diff-check
     - taplo@0.9.3
-    - actionlint@1.7.3
+    - actionlint@1.7.6
     - clippy@1.76.0
-    - gitleaks@8.20.1
-    - markdownlint@0.42.0
-    - prettier@3.3.3
+    - gitleaks@8.22.1
+    - markdownlint@0.43.0
+    - prettier@3.4.2
     - rustfmt@1.76.0
 actions:
   enabled:


### PR DESCRIPTION
I've been getting spammed with this, and we can't use it without the nontrivial step of setting up the creds. Disabled for now and upgraded the `.trunk/trunk.yaml`