### PR TITLE
claude/never-edit-restore-upstream-sFuGQ

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -199,6 +199,25 @@ pub fn modified_since(upstream: &str, repo_path: Option<&Path>) -> anyhow::Resul
     Ok(ret)
 }
 
+pub fn get_upstream_content(
+    upstream: &str,
+    file_path: &str,
+    repo_path: Option<&Path>,
+) -> anyhow::Result<String> {
+    let path = repo_path.unwrap_or(Path::new("."));
+    let repo = Repository::open(path)?;
+
+    let upstream_tree = match repo.find_reference(upstream) {
+        Ok(reference) => reference.peel_to_tree()?,
+        _ => repo.revparse_single(upstream)?.peel_to_tree()?,
+    };
+
+    let entry = upstream_tree.get_path(Path::new(file_path))?;
+    let blob = repo.find_blob(entry.id())?;
+    let content = std::str::from_utf8(blob.content())?;
+    Ok(content.to_string())
+}
+
 pub fn clone(repo_url: &str, destination: &Path) -> Output {
     let output = Command::new("git")
         .args([

--- a/src/rules/never_edit.rs
+++ b/src/rules/never_edit.rs
@@ -118,10 +118,7 @@ pub fn never_edit(run: &Run, upstream: &str) -> anyhow::Result<Vec<diagnostic::D
         if let Some(status) = modified.paths.get(protected_file) {
             match status {
                 FileStatus::Modified => {
-                    let replacements = build_restore_replacement(
-                        upstream,
-                        protected_file,
-                    );
+                    let replacements = build_restore_replacement(upstream, protected_file);
                     diagnostics.push(diagnostic::Diagnostic {
                         path: protected_file.clone(),
                         range: None,
@@ -132,10 +129,7 @@ pub fn never_edit(run: &Run, upstream: &str) -> anyhow::Result<Vec<diagnostic::D
                     });
                 }
                 FileStatus::Deleted => {
-                    let replacements = build_restore_replacement(
-                        upstream,
-                        protected_file,
-                    );
+                    let replacements = build_restore_replacement(upstream, protected_file);
                     diagnostics.push(diagnostic::Diagnostic {
                         path: protected_file.clone(),
                         range: None,

--- a/src/rules/never_edit.rs
+++ b/src/rules/never_edit.rs
@@ -118,23 +118,31 @@ pub fn never_edit(run: &Run, upstream: &str) -> anyhow::Result<Vec<diagnostic::D
         if let Some(status) = modified.paths.get(protected_file) {
             match status {
                 FileStatus::Modified => {
+                    let replacements = build_restore_replacement(
+                        upstream,
+                        protected_file,
+                    );
                     diagnostics.push(diagnostic::Diagnostic {
                         path: protected_file.clone(),
                         range: None,
                         severity: diagnostic::Severity::Error,
                         code: "never-edit-modified".to_string(),
                         message: "file is protected and should not be modified".to_string(),
-                        replacements: None,
+                        replacements,
                     });
                 }
                 FileStatus::Deleted => {
+                    let replacements = build_restore_replacement(
+                        upstream,
+                        protected_file,
+                    );
                     diagnostics.push(diagnostic::Diagnostic {
                         path: protected_file.clone(),
                         range: None,
                         severity: diagnostic::Severity::Warning,
                         code: "never-edit-deleted".to_string(),
                         message: "file is protected and should not be deleted".to_string(),
-                        replacements: None,
+                        replacements,
                     });
                 }
                 _ => {}
@@ -152,4 +160,55 @@ pub fn never_edit(run: &Run, upstream: &str) -> anyhow::Result<Vec<diagnostic::D
     });
 
     Ok(diagnostics)
+}
+
+/// Build a replacement that restores the upstream version of a file.
+/// For modified files, this replaces the entire local content with the upstream content.
+/// For deleted files, this inserts the upstream content to recreate the file.
+fn build_restore_replacement(
+    upstream: &str,
+    file_path: &str,
+) -> Option<Vec<diagnostic::Replacement>> {
+    let upstream_text = match git::get_upstream_content(upstream, file_path, None) {
+        Ok(content) => content,
+        Err(e) => {
+            debug!("failed to get upstream content for {}: {}", file_path, e);
+            return None;
+        }
+    };
+
+    // Determine the region to delete based on local file content.
+    // If the file still exists (modified), delete all its content.
+    // If the file was deleted, use an empty region (0,0)-(0,0).
+    let deleted_region = if let Ok(current_text) = std::fs::read_to_string(file_path) {
+        let lines: Vec<&str> = current_text.split('\n').collect();
+        let last_line_idx = lines.len().saturating_sub(1);
+        let last_line_len = lines.last().map_or(0, |l| l.len());
+        diagnostic::Range {
+            start: diagnostic::Position {
+                line: 0,
+                character: 0,
+            },
+            end: diagnostic::Position {
+                line: last_line_idx as u64,
+                character: last_line_len as u64,
+            },
+        }
+    } else {
+        diagnostic::Range {
+            start: diagnostic::Position {
+                line: 0,
+                character: 0,
+            },
+            end: diagnostic::Position {
+                line: 0,
+                character: 0,
+            },
+        }
+    };
+
+    Some(vec![diagnostic::Replacement {
+        deleted_region,
+        inserted_content: upstream_text,
+    }])
 }

--- a/tests/integration_testing.rs
+++ b/tests/integration_testing.rs
@@ -66,6 +66,34 @@ impl HortonOutput {
     }
 
     #[allow(dead_code)]
+    pub fn has_fix_with_content(&self, rule_id: &str, expected_content: &str) -> bool {
+        for run in self.runs() {
+            if let Some(results) = run.results {
+                for result in results {
+                    if result.rule_id.as_deref() == Some(rule_id) {
+                        if let Some(fixes) = &result.fixes {
+                            for fix in fixes {
+                                for change in &fix.artifact_changes {
+                                    for replacement in &change.replacements {
+                                        if let Some(content) = &replacement.inserted_content {
+                                            if let Some(text) = &content.text {
+                                                if text.contains(expected_content) {
+                                                    return true;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    #[allow(dead_code)]
     pub fn has_result_with_rule_id(&self, rule_id: &str) -> bool {
         // Iterate over the runs and results to find the matching code and message
         for run in self.runs() {

--- a/tests/never_edit_test.rs
+++ b/tests/never_edit_test.rs
@@ -34,6 +34,8 @@ fn assert_modified_locked_file() -> anyhow::Result<()> {
         Some("src/write_once.txt"),
     ))
     .is_true();
+    // Verify the fix proposes restoring the upstream content
+    assert_that(&horton.has_fix_with_content("never-edit-modified", "immutable text")).is_true();
     assert_that(&horton.has_result("never-edit-modified", "", Some("src/write_many.txt")))
         .is_false();
 
@@ -66,6 +68,8 @@ fn assert_deleted_locked_file() -> anyhow::Result<()> {
     assert_that(&horton.exit_code).contains_value(0);
     assert_that(&horton.has_result("never-edit-deleted", "", Some("src/locked/file.txt")))
         .is_true();
+    // Verify the fix proposes restoring the upstream content
+    assert_that(&horton.has_fix_with_content("never-edit-deleted", "immutable text")).is_true();
 
     Ok(())
 }


### PR DESCRIPTION
When a protected file is modified or deleted, the never-edit diagnostic
now includes a SARIF replacement that restores the file to its upstream
version. This gives tooling the ability to automatically undo violations
by replacing local content with the original upstream content.

https://claude.ai/code/session_014Ev8EeSctAKfjw3tX14weS