### PR TITLE
Remove unused git.rs helpers and chrono dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,9 +182,7 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
  "windows-targets",
 ]
 
@@ -1431,7 +1429,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "chrono",
  "clap",
  "confique",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ rayon = "1.10.0"
 confique = "0.2.5"
 glob = "0.3.1"
 glob-match = "0.2.1"
-chrono = "0.4.38"
 log4rs = "1.3.0"
 
 [dev-dependencies]

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,10 +1,7 @@
-use chrono::{DateTime, FixedOffset};
 use git2::{AttrCheckFlags, AttrValue, Delta, DiffOptions, Repository};
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::process::Output as ProcessOutput;
 use std::sync::Mutex;
 #[derive(Debug, Clone)]
 pub struct Hunk {
@@ -33,26 +30,6 @@ pub struct FileChanges {
     pub paths: HashMap<String, FileStatus>,
 }
 
-pub struct Output {
-    pub status: std::process::ExitStatus,
-    pub stdout: String,
-    pub stderr: String,
-}
-
-pub struct Commit {
-    pub hash: String,
-    pub date: DateTime<FixedOffset>,
-}
-
-impl Output {
-    pub fn new(po: ProcessOutput) -> Self {
-        Self {
-            status: po.status,
-            stdout: String::from_utf8_lossy(&po.stdout).to_string(),
-            stderr: String::from_utf8_lossy(&po.stderr).to_string(),
-        }
-    }
-}
 lazy_static! {
     static ref LFS_CACHE: Mutex<HashMap<String, bool>> = Mutex::new(HashMap::new());
 }
@@ -216,73 +193,4 @@ pub fn get_upstream_content(
     let blob = repo.find_blob(entry.id())?;
     let content = std::str::from_utf8(blob.content())?;
     Ok(content.to_string())
-}
-
-pub fn clone(repo_url: &str, destination: &Path) -> Output {
-    let output = Command::new("git")
-        .args([
-            "clone",
-            "--no-checkout",
-            "--bare",
-            "--filter=blob:none",
-            repo_url,
-            destination.to_string_lossy().as_ref(),
-        ])
-        .output()
-        .expect("Failed to execute git command");
-
-    Output::new(output)
-}
-
-pub fn status(dir: &PathBuf) -> Output {
-    let output = Command::new("git")
-        .args(["status", "--porcelain"])
-        .current_dir(dir)
-        .output()
-        .expect("Failed to execute git command");
-
-    Output::new(output)
-}
-
-pub fn dir_inside_git_repo(dir: &PathBuf) -> bool {
-    let output = Command::new("git")
-        .args(["rev-parse", "--is-inside-work-tree"])
-        .current_dir(dir)
-        .output()
-        .expect("Failed to execute git command");
-
-    output.status.success()
-}
-
-pub fn last_commit(dir: &PathBuf, file: &str) -> Result<Commit, String> {
-    let result = Command::new("git")
-        .args([
-            "--no-pager",
-            "log",
-            "-1",
-            "--pretty=format:%H%n%ci",
-            "--",
-            file,
-        ])
-        .current_dir(dir)
-        .output()
-        .expect("Failed to execute git command");
-
-    let output = Output::new(result);
-
-    if output.status.success() {
-        if output.stdout.is_empty() {
-            return Err("No file history found".to_string());
-        } else {
-            let mut lines: std::str::Lines<'_> = output.stdout.lines();
-            let hash = lines.next().ok_or("Missing hash").unwrap();
-            let date_str = lines.next().ok_or("Missing date").unwrap();
-
-            return Ok(Commit {
-                hash: hash.to_string(),
-                date: DateTime::parse_from_str(date_str, "%Y-%m-%d %H:%M:%S %z").unwrap(),
-            });
-        }
-    }
-    Err(output.stderr)
 }


### PR DESCRIPTION
## Summary

- Removes four `git.rs` helper functions that aren't called anywhere in this crate: `clone`, `status`, `dir_inside_git_repo`, `last_commit`.
- Removes the `Output` and `Commit` structs that only existed to support those dead helpers.
- Drops the direct `chrono` dependency, which was only used by `last_commit`. (log4rs still pulls chrono transitively; no binary-size change.)
- Drops the `std::process::Command` usage that only the removed helpers needed.

**Stacked on top of #60.**

## Test plan
- [x] `cargo build` clean, zero warnings
- [x] `cargo fmt --check` clean
- [ ] CI

https://claude.ai/code/session_014Ev8EeSctAKfjw3tX14weS