### PR TITLE
Replace spectral (unmaintained) with builtin assert macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,12 +456,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,7 +708,7 @@ dependencies = [
  "log-mdc",
  "once_cell",
  "parking_lot",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde-value",
  "serde_json",
@@ -730,74 +724,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "num"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
-dependencies = [
- "num-integer",
- "num-traits",
- "rand 0.4.6",
- "rustc-serialize",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
-dependencies = [
- "num-traits",
- "rustc-serialize",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
- "rustc-serialize",
-]
 
 [[package]]
 name = "num-traits"
@@ -969,26 +895,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -998,23 +911,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1043,15 +941,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1091,12 +980,6 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "rustix"
@@ -1262,15 +1145,6 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "spectral"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
-dependencies = [
- "num",
-]
 
 [[package]]
 name = "strsim"
@@ -1442,7 +1316,6 @@ dependencies = [
  "serde",
  "serde-sarif",
  "serde_json",
- "spectral",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ log4rs = "1.3.0"
 
 [dev-dependencies]
 assert_cmd = "2.0"
-spectral = "0.6.0"
 tempfile = "3.3.0"
 
 [profile.release]

--- a/tests/do_not_land_test.rs
+++ b/tests/do_not_land_test.rs
@@ -1,6 +1,4 @@
 // trunk-ignore-all(trunk-toolbox/do-not-land)
-use spectral::prelude::*;
-
 mod integration_testing;
 use integration_testing::TestRepo;
 
@@ -15,9 +13,8 @@ fn basic() -> anyhow::Result<()> {
     test_repo.git_add_all()?;
     let horton = test_repo.run_horton()?;
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.has_result("do-not-land", "Found 'do-NOT-lAnD'", Some("alpha.foo")))
-        .is_true();
+    assert_eq!(horton.exit_code, Some(0));
+    assert!(horton.has_result("do-not-land", "Found 'do-NOT-lAnD'", Some("alpha.foo")));
 
     Ok(())
 }
@@ -30,8 +27,8 @@ fn binary_files_ignored() -> anyhow::Result<()> {
     test_repo.git_add_all()?;
     let horton = test_repo.run_horton()?;
 
-    assert_that(&horton.runs()).has_length(1);
-    assert_that(&horton.has_result_with_rule_id("do-not-land")).is_false();
+    assert_eq!(horton.runs().len(), 1);
+    assert!(!horton.has_result_with_rule_id("do-not-land"));
 
     Ok(())
 }
@@ -44,7 +41,7 @@ fn honor_disabled_in_config() -> anyhow::Result<()> {
 
     {
         let horton = test_repo.run_horton()?;
-        assert_that(&horton.has_result_with_rule_id("do-not-land")).is_true();
+        assert!(horton.has_result_with_rule_id("do-not-land"));
     }
 
     let config = r#"
@@ -56,7 +53,7 @@ fn honor_disabled_in_config() -> anyhow::Result<()> {
     test_repo.write("toolbox.toml", config.as_bytes());
     {
         let horton = test_repo.run_horton().unwrap();
-        assert_that(&horton.has_result_with_rule_id("do-not-land")).is_false();
+        assert!(!horton.has_result_with_rule_id("do-not-land"));
     }
 
     Ok(())

--- a/tests/if_change_then_change_test.rs
+++ b/tests/if_change_then_change_test.rs
@@ -1,5 +1,3 @@
-use spectral::prelude::*;
-
 mod integration_testing;
 use integration_testing::TestRepo;
 use std::path::PathBuf;
@@ -19,13 +17,12 @@ fn assert_no_expected_changes(before: &str, after: &str) -> anyhow::Result<()> {
 
     print!("{}", horton.stdout);
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.has_result(
+    assert_eq!(horton.exit_code, Some(0));
+    assert!(!horton.has_result(
         "if-change-then-change-this",
         "Expected change in constant.foo because revision.foo was modified",
         Some("revision.foo"),
-    ))
-    .is_false();
+    ));
 
     Ok(())
 }
@@ -40,13 +37,12 @@ fn assert_expected_change_in_constant_foo(before: &str, after: &str) -> anyhow::
     test_repo.write("revision.foo", after.as_bytes());
     let horton = test_repo.run_horton()?;
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.has_result(
+    assert_eq!(horton.exit_code, Some(0));
+    assert!(horton.has_result(
         "if-change-then-change-this",
         "Expected change in constant.foo because revision.foo was modified",
         Some("revision.foo"),
-    ))
-    .is_true();
+    ));
     Ok(())
 }
 
@@ -277,25 +273,23 @@ fn assert_missing_thenchange() {
     {
         test_repo.write("revision.foo", single_tag.as_bytes());
         let horton = test_repo.run_horton().unwrap();
-        assert_that(&horton.exit_code).contains_value(0);
-        assert_that(&horton.has_result(
+        assert_eq!(horton.exit_code, Some(0));
+        assert!(horton.has_result(
             "if-change-mismatched",
             "Expected matching ThenChange tag",
             None,
-        ))
-        .is_true();
+        ));
     }
 
     {
         test_repo.write("revision.foo", multi_tag.as_bytes());
         let horton = test_repo.run_horton().unwrap();
-        assert_that(&horton.exit_code).contains_value(0);
-        assert_that(&horton.has_result(
+        assert_eq!(horton.exit_code, Some(0));
+        assert!(horton.has_result(
             "if-change-mismatched",
             "Expected matching ThenChange tag",
             None,
-        ))
-        .is_true();
+        ));
     }
 }
 
@@ -329,26 +323,23 @@ fn assert_missing_ifchange() {
     {
         test_repo.write("revision.foo", single_tag.as_bytes());
         let horton = test_repo.run_horton().unwrap();
-        assert_that(&horton.exit_code).contains_value(0);
-        assert_that(&horton.has_result(
+        assert_eq!(horton.exit_code, Some(0));
+        assert!(horton.has_result(
             "if-change-mismatched",
             "Expected preceding IfChange tag",
             None,
-        ))
-        .is_true();
-        assert_that(&horton.stdout).contains("");
+        ));
     }
 
     {
         test_repo.write("revision.foo", multi_tag.as_bytes());
         let horton = test_repo.run_horton().unwrap();
-        assert_that(&horton.exit_code).contains_value(0);
-        assert_that(&horton.has_result(
+        assert_eq!(horton.exit_code, Some(0));
+        assert!(horton.has_result(
             "if-change-mismatched",
             "Expected preceding IfChange tag",
             None,
-        ))
-        .is_true();
+        ));
     }
 }
 
@@ -371,13 +362,12 @@ fn assert_localfile_notfound() {
     {
         test_repo.write("revision.foo", missing_file.as_bytes());
         let horton = test_repo.run_horton().unwrap();
-        assert_that(&horton.exit_code).contains_value(0);
-        assert_that(&horton.has_result(
+        assert_eq!(horton.exit_code, Some(0));
+        assert!(horton.has_result(
             "if-change-file-does-not-exist",
             "ThenChange zee.foo does not exist",
             None,
-        ))
-        .is_true();
+        ));
     }
 }
 

--- a/tests/main_test.rs
+++ b/tests/main_test.rs
@@ -1,5 +1,3 @@
-use spectral::prelude::*;
-
 mod integration_testing;
 use integration_testing::TestRepo;
 
@@ -11,8 +9,8 @@ fn binary_file_untracked() -> anyhow::Result<()> {
 
     let horton = test_repo.run_horton()?;
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.stdout.contains("Expected change")).is_false();
+    assert_eq!(horton.exit_code, Some(0));
+    assert!(!horton.stdout.contains("Expected change"));
     Ok(())
 }
 
@@ -27,8 +25,8 @@ fn binary_file_committed() -> anyhow::Result<()> {
 
     print!("{}", horton.stdout);
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.stdout.contains("Expected change")).is_false();
+    assert_eq!(horton.exit_code, Some(0));
+    assert!(!horton.stdout.contains("Expected change"));
 
     Ok(())
 }
@@ -47,8 +45,8 @@ fn lfs_file_untracked() -> anyhow::Result<()> {
 
     let horton = test_repo.run_horton()?;
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.stdout.contains("Expected change")).is_false();
+    assert_eq!(horton.exit_code, Some(0));
+    assert!(!horton.stdout.contains("Expected change"));
 
     Ok(())
 }
@@ -67,8 +65,8 @@ fn lfs_file_committed() -> anyhow::Result<()> {
 
     let horton = test_repo.run_horton_with("HEAD^", "sarif", false)?;
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.stdout.contains("Expected change")).is_false();
+    assert_eq!(horton.exit_code, Some(0));
+    assert!(!horton.stdout.contains("Expected change"));
 
     Ok(())
 }

--- a/tests/never_edit_test.rs
+++ b/tests/never_edit_test.rs
@@ -1,5 +1,3 @@
-use spectral::prelude::*;
-
 mod integration_testing;
 use integration_testing::TestRepo;
 
@@ -27,17 +25,15 @@ fn assert_modified_locked_file() -> anyhow::Result<()> {
 
     let horton = test_repo.run_horton()?;
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.has_result(
+    assert_eq!(horton.exit_code, Some(0));
+    assert!(horton.has_result(
         "never-edit-modified",
         "file is protected and should not be modified",
         Some("src/write_once.txt"),
-    ))
-    .is_true();
+    ));
     // Verify the fix proposes restoring the upstream content
-    assert_that(&horton.has_fix_with_content("never-edit-modified", "immutable text")).is_true();
-    assert_that(&horton.has_result("never-edit-modified", "", Some("src/write_many.txt")))
-        .is_false();
+    assert!(horton.has_fix_with_content("never-edit-modified", "immutable text"));
+    assert!(!horton.has_result("never-edit-modified", "", Some("src/write_many.txt")));
 
     Ok(())
 }
@@ -65,11 +61,10 @@ fn assert_deleted_locked_file() -> anyhow::Result<()> {
 
     let horton = test_repo.run_horton()?;
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.has_result("never-edit-deleted", "", Some("src/locked/file.txt")))
-        .is_true();
+    assert_eq!(horton.exit_code, Some(0));
+    assert!(horton.has_result("never-edit-deleted", "", Some("src/locked/file.txt")));
     // Verify the fix proposes restoring the upstream content
-    assert_that(&horton.has_fix_with_content("never-edit-deleted", "immutable text")).is_true();
+    assert!(horton.has_fix_with_content("never-edit-deleted", "immutable text"));
 
     Ok(())
 }
@@ -100,16 +95,14 @@ fn honor_disabled_in_config() -> anyhow::Result<()> {
 
     test_repo.set_toolbox_toml(toml_on);
     let mut horton = test_repo.run_horton()?;
-    assert_that(&horton.has_result("never-edit-deleted", "", Some("src/locked/file.txt")))
-        .is_true();
+    assert!(horton.has_result("never-edit-deleted", "", Some("src/locked/file.txt")));
 
     test_repo.set_toolbox_toml(toml_off);
     horton = test_repo.run_horton()?;
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.has_result("never-edit-deleted", "", Some("src/locked/file.txt")))
-        .is_false();
-    assert_that(&horton.has_result("toolbox-perf", "1 files processed", None)).is_true();
+    assert_eq!(horton.exit_code, Some(0));
+    assert!(!horton.has_result("never-edit-deleted", "", Some("src/locked/file.txt")));
+    assert!(horton.has_result("toolbox-perf", "1 files processed", None));
 
     Ok(())
 }
@@ -128,7 +121,7 @@ fn warn_for_config_not_protecting_anything() -> anyhow::Result<()> {
 
     let horton: integration_testing::HortonOutput = test_repo.run_horton()?;
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.has_result_with_rule_id("never-edit-bad-config")).is_true();
+    assert_eq!(horton.exit_code, Some(0));
+    assert!(horton.has_result_with_rule_id("never-edit-bad-config"));
     Ok(())
 }

--- a/tests/no_curly_quote_test.rs
+++ b/tests/no_curly_quote_test.rs
@@ -1,5 +1,3 @@
-use spectral::prelude::*;
-
 mod integration_testing;
 use integration_testing::TestRepo;
 
@@ -35,14 +33,14 @@ fn honor_disabled_in_config() -> anyhow::Result<()> {
 
     test_repo.set_toolbox_toml(TOML_ON);
     let mut horton = test_repo.run_horton()?;
-    assert_that(&horton.has_result("no-curly-quotes", "", Some("src/curly.txt"))).is_true();
+    assert!(horton.has_result("no-curly-quotes", "", Some("src/curly.txt")));
 
     test_repo.set_toolbox_toml(toml_off);
     horton = test_repo.run_horton()?;
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.has_result("no-curly-quotes", "", Some("src/curly.txt"))).is_false();
-    assert_that(&horton.has_result("toolbox-perf", "1 files processed", None)).is_true();
+    assert_eq!(horton.exit_code, Some(0));
+    assert!(!horton.has_result("no-curly-quotes", "", Some("src/curly.txt")));
+    assert!(horton.has_result("toolbox-perf", "1 files processed", None));
 
     Ok(())
 }
@@ -57,30 +55,26 @@ fn assert_find_curly_quotes() {
     {
         test_repo.write("revision.foo", CURLY_QUOTES.as_bytes());
         let horton = test_repo.run_horton().unwrap();
-        assert_that(&horton.exit_code).contains_value(0);
-        assert_that(&horton.has_result(
+        assert_eq!(horton.exit_code, Some(0));
+        assert!(horton.has_result(
             "no-curly-quotes",
             "Found curly quote on line 2",
             Some("revision.foo"),
-        ))
-        .is_true();
-        assert_that(&horton.has_result(
+        ));
+        assert!(horton.has_result(
             "no-curly-quotes",
             "Found curly quote on line 3",
             Some("revision.foo"),
-        ))
-        .is_true();
-        assert_that(&horton.has_result(
+        ));
+        assert!(horton.has_result(
             "no-curly-quotes",
             "Found curly quote on line 4",
             Some("revision.foo"),
-        ))
-        .is_true();
-        assert_that(&horton.has_result(
+        ));
+        assert!(horton.has_result(
             "no-curly-quotes",
             "Found curly quote on line 5",
             Some("revision.foo"),
-        ))
-        .is_true();
+        ));
     }
 }

--- a/tests/output_format_test.rs
+++ b/tests/output_format_test.rs
@@ -3,7 +3,6 @@ extern crate regex;
 
 use serde_json::Error;
 use serde_sarif::sarif::Sarif;
-use spectral::prelude::*;
 
 mod integration_testing;
 use integration_testing::TestRepo;
@@ -20,8 +19,8 @@ fn default_sarif() -> anyhow::Result<()> {
     let horton = test_repo.run_horton_with("HEAD", "sarif", false)?;
 
     let sarif: Result<Sarif, Error> = serde_json::from_str(&horton.stdout);
-    assert_that(&sarif.is_ok()).is_true();
-    assert_that(&sarif.unwrap().runs).has_length(1);
+    assert!(sarif.is_ok());
+    assert_eq!(sarif.unwrap().runs.len(), 1);
 
     Ok(())
 }
@@ -40,8 +39,8 @@ fn default_print() -> anyhow::Result<()> {
         "alpha.foo:1:0: Found 'do-NOT-lAnD' (error)\nalpha.foo:2:0: Found 'DONOTLAND' (error)\n",
     );
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.stdout).is_equal_to(&expected_text);
+    assert_eq!(horton.exit_code, Some(0));
+    assert_eq!(horton.stdout, expected_text);
 
     Ok(())
 }

--- a/tests/todo_test.rs
+++ b/tests/todo_test.rs
@@ -1,6 +1,4 @@
 // trunk-ignore-all(trunk-toolbox/todo)
-use spectral::prelude::*;
-
 mod integration_testing;
 use integration_testing::TestRepo;
 
@@ -28,8 +26,8 @@ fn basic_todo() -> anyhow::Result<()> {
     test_repo.git_add_all()?;
     let horton = test_repo.run_horton()?;
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.has_result_with_rule_id("todo")).is_true();
+    assert_eq!(horton.exit_code, Some(0));
+    assert!(horton.has_result_with_rule_id("todo"));
 
     Ok(())
 }
@@ -46,8 +44,8 @@ fn basic_fixme() -> anyhow::Result<()> {
     test_repo.git_add_all()?;
     let horton = test_repo.run_horton()?;
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.has_result("todo", "Found 'FIXME'", Some("alpha.foo"))).is_true();
+    assert_eq!(horton.exit_code, Some(0));
+    assert!(horton.has_result("todo", "Found 'FIXME'", Some("alpha.foo")));
 
     Ok(())
 }
@@ -64,8 +62,8 @@ fn basic_mastodon() -> anyhow::Result<()> {
     test_repo.git_add_all()?;
     let horton = test_repo.run_horton()?;
 
-    assert_that(&horton.exit_code).contains_value(0);
-    assert_that(&horton.stdout.contains("Found 'todo'")).is_false();
+    assert_eq!(horton.exit_code, Some(0));
+    assert!(!horton.stdout.contains("Found 'todo'"));
 
     Ok(())
 }
@@ -78,7 +76,7 @@ fn default_disabled_in_config() -> anyhow::Result<()> {
 
     {
         let horton = test_repo.run_horton()?;
-        assert_that(&horton.stdout.contains("Found 'todo'")).is_false();
+        assert!(!horton.stdout.contains("Found 'todo'"));
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

`spectral` is unmaintained (last release 2017) and its fluent API was only used for five assertion patterns, all of which have direct builtin equivalents:

| spectral                               | replacement                |
| -------------------------------------- | -------------------------- |
| `assert_that(&x).contains_value(y)`    | `assert_eq!(x, Some(y))`   |
| `assert_that(&x).is_true()`            | `assert!(x)`               |
| `assert_that(&x).is_false()`           | `assert!(!x)`              |
| `assert_that(&x).has_length(n)`        | `assert_eq!(x.len(), n)`   |
| `assert_that(&x).is_equal_to(&y)`      | `assert_eq!(x, y)`         |

Dropped the dev-dependency entirely. One line — `assert_that(&horton.stdout).contains("")` — was deleted because every string contains the empty string, so the assertion was a no-op.

**Stacked on top of #62.**

## Test plan
- [x] `cargo build --tests` clean
- [x] `cargo fmt --check` clean
- [ ] CI

https://claude.ai/code/session_014Ev8EeSctAKfjw3tX14weS