### PR TITLE
Remove duplicate Trunk Check workflow job

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,15 +28,3 @@ jobs:
           org-slug: trunk
           token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
         continue-on-error: true
-
-  trunk_check_runner:
-    name: Trunk Check runner [linux]
-    runs-on: [ubuntu-latest]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Trunk Check
-        uses: trunk-io/trunk-action@v1
-        with:
-          cache: false


### PR DESCRIPTION
## Summary

Every PR currently shows two "Trunk Check" statuses:

- **Trunk Check** — posted by the Trunk Check GitHub App (installed on the repo, runs on every PR automatically).
- **Trunk Check runner [linux]** — the `trunk_check_runner` job in `pr.yaml` invoking `trunk-io/trunk-action@v1`.

They run the same check. Dropping the workflow job leaves a single source of truth.

**Note:** the remaining status is named `Trunk Check`. If `Trunk Check runner [linux]` is configured as a required status check on `main` branch protection, that rule also needs to be updated to point at `Trunk Check`.

**Stacked on top of #63.**

## Test plan
- [ ] Confirm the single remaining "Trunk Check" status still runs & blocks on CI
- [ ] Update branch protection if "Trunk Check runner [linux]" was listed as required

https://claude.ai/code/session_014Ev8EeSctAKfjw3tX14weS