### PR TITLE
Bump Rust toolchain 1.82 -> 1.85

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -13,7 +13,7 @@ runtimes:
     - python@3.10.8
     - go@1.21.0
     - node@18.20.5
-    - rust@1.82.0
+    - rust@1.85.0
 tools:
   enabled:
     - gh@2.65.0

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.85.0"


### PR DESCRIPTION
## Summary

Bumps the pinned Rust toolchain from **1.82.0 → 1.85.0** (also updates `.trunk/trunk.yaml`'s `rust` runtime to match).

This is a prerequisite for the confique 0.3 bump in the next stacked PR: confique 0.3.x pulls in newer `toml`, `serde_spanned`, and `toml_datetime` releases that require Rust edition 2024, which was stabilized in 1.85. On 1.82 cargo rejects them with:

```
feature `edition2024` is required
```

Verified locally with 1.85.0: `cargo build` clean with zero warnings, `cargo fmt --check` clean.

**Stacked on top of #64.**

## Test plan
- [x] `cargo build` passes on 1.85.0
- [x] `cargo fmt --check` passes
- [ ] CI

https://claude.ai/code/session_014Ev8EeSctAKfjw3tX14weS