### PR TITLE
Unify rule orchestration and fix design issues

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,3 +28,15 @@ jobs:
           org-slug: trunk
           token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
         continue-on-error: true
+
+  trunk_check_runner:
+    name: Trunk Check runner [linux]
+    runs-on: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Trunk Check
+        uses: trunk-io/trunk-action@v1
+        with:
+          cache: false

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -63,11 +63,11 @@ lint:
     - git-diff-check
     - taplo@0.9.3
     - actionlint@1.7.6
-    - clippy@1.76.0
+    - clippy@1.85.0
     - gitleaks@8.22.1
     - markdownlint@0.43.0
     - prettier@3.4.2
-    - rustfmt@1.76.0
+    - rustfmt@1.85.0
 actions:
   enabled:
     - trunk-upgrade-available

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,6 @@ dependencies = [
  "git2",
  "glob",
  "glob-match",
- "lazy_static",
  "log",
  "log4rs",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/lib.rs"
 anyhow = "1.0.64"
 clap = { version = "4.0.8", features = ["derive"] }
 git2 = { version = "0.19", default-features = false }
-lazy_static = "1.4.0"
 log = "0.4.22"
 regex = "1.10.6"
 serde = { version = "1.0.209", features = ["derive"] }

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,8 +1,7 @@
 use git2::{AttrCheckFlags, AttrValue, Delta, DiffOptions, Repository};
-use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::RwLock;
+use std::sync::{LazyLock, RwLock};
 #[derive(Debug, Clone)]
 pub struct Hunk {
     pub path: PathBuf,
@@ -27,15 +26,11 @@ pub struct FileChanges {
     pub hunks: Vec<Hunk>,
 
     /// Map of changed files and FileStatus
-    pub paths: HashMap<String, FileStatus>,
+    pub paths: HashMap<PathBuf, FileStatus>,
 }
 
-lazy_static! {
-    // RwLock lets concurrent cache hits (the common case, once a path has been seen) proceed
-    // without serializing. A Mutex would force every lookup to serialize against every other
-    // lookup, even though lookups don't mutate the map.
-    static ref LFS_CACHE: RwLock<HashMap<String, bool>> = RwLock::new(HashMap::new());
-}
+static LFS_CACHE: LazyLock<RwLock<HashMap<String, bool>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
 
 fn is_lfs(repo: &Repository, path: &Path) -> bool {
     let path_str = path.to_string_lossy().to_string();
@@ -107,16 +102,13 @@ pub fn modified_since(upstream: &str, repo_path: Option<&Path>) -> anyhow::Resul
                 if !is_lfs(&repo, path) {
                     match delta.status() {
                         Delta::Added => {
-                            ret.paths
-                                .insert(path.to_string_lossy().to_string(), FileStatus::Added);
+                            ret.paths.insert(path.to_path_buf(), FileStatus::Added);
                         }
                         Delta::Modified => {
-                            ret.paths
-                                .insert(path.to_string_lossy().to_string(), FileStatus::Modified);
+                            ret.paths.insert(path.to_path_buf(), FileStatus::Modified);
                         }
                         Delta::Deleted => {
-                            ret.paths
-                                .insert(path.to_string_lossy().to_string(), FileStatus::Deleted);
+                            ret.paths.insert(path.to_path_buf(), FileStatus::Deleted);
                         }
                         _ => {}
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,10 @@ use clap::Parser;
 use confique::Config;
 use horton::config::Conf;
 use horton::diagnostic;
-use horton::rules::if_change_then_change::ictc;
-use horton::rules::never_edit::never_edit;
-use horton::rules::no_curly_quotes::no_curly_quotes;
-use horton::rules::pls_no_land::pls_no_land;
+use horton::rules::RULES;
 use horton::run::{Cli, OutputFormat, Run, Subcommands};
 
+use anyhow::Context;
 use log::{debug, warn};
 use serde_sarif::sarif;
 use std::env;
@@ -137,34 +135,33 @@ fn run() -> anyhow::Result<()> {
             std::process::exit(1);
         });
 
+    let upstream_mode = cli.upstream_mode || cli.cache_dir.ends_with("-upstream");
+
     let run = Run {
         paths: cli.files.into_iter().map(PathBuf::from).collect(),
         config,
         config_path: toolbox_toml,
         cache_dir: cli.cache_dir.clone(),
+        upstream_mode,
     };
 
-    // Run all rules in parallel. Each rule writes its result into its own slot; after the
-    // scope ends we collect results and propagate the first error, if any.
-    let mut pls_no_land_result: anyhow::Result<Vec<diagnostic::Diagnostic>> = Ok(vec![]);
-    let mut ictc_result: anyhow::Result<Vec<diagnostic::Diagnostic>> = Ok(vec![]);
-    let mut never_edit_result: anyhow::Result<Vec<diagnostic::Diagnostic>> = Ok(vec![]);
-    let mut no_curly_quotes_result: anyhow::Result<Vec<diagnostic::Diagnostic>> = Ok(vec![]);
+    let mut results: Vec<anyhow::Result<Vec<diagnostic::Diagnostic>>> =
+        RULES.iter().map(|_| Ok(vec![])).collect();
 
     rayon::scope(|s| {
-        s.spawn(|_| pls_no_land_result = pls_no_land(&run));
-        s.spawn(|_| ictc_result = ictc(&run, &cli.upstream));
-        s.spawn(|_| never_edit_result = never_edit(&run, &cli.upstream));
-        s.spawn(|_| no_curly_quotes_result = no_curly_quotes(&run, &cli.upstream));
+        for (result, (_, rule_fn)) in results.iter_mut().zip(RULES.iter()) {
+            let run = &run;
+            let upstream = cli.upstream.as_str();
+            s.spawn(move |_| {
+                *result = rule_fn(run, upstream);
+            });
+        }
     });
 
-    for rule_result in [
-        pls_no_land_result,
-        ictc_result,
-        never_edit_result,
-        no_curly_quotes_result,
-    ] {
-        ret.diagnostics.extend(rule_result?);
+    for (i, result) in results.into_iter().enumerate() {
+        let rule_name = RULES[i].0;
+        ret.diagnostics
+            .extend(result.with_context(|| format!("rule '{}' failed", rule_name))?);
     }
 
     let mut output_string = generate_line_string(&ret);

--- a/src/rules/if_change_then_change.rs
+++ b/src/rules/if_change_then_change.rs
@@ -8,6 +8,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
 use crate::diagnostic;
 use crate::git;
@@ -43,10 +44,10 @@ impl IctcBlock {
     }
 }
 
-lazy_static::lazy_static! {
-    static ref RE_BEGIN: Regex = Regex::new(r"(?i)^\s*(//|#)\s*ifchange(.*)$").unwrap();
-    static ref RE_END: Regex = Regex::new(r"(?i)^\s*(//|#)\s*thenchange(.*)$").unwrap();
-}
+static RE_BEGIN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*(//|#)\s*ifchange(.*)$").unwrap());
+static RE_END: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*(//|#)\s*thenchange(.*)$").unwrap());
 
 pub fn find_ictc_blocks(path: &PathBuf) -> anyhow::Result<Vec<IctcBlock>> {
     let mut blocks: Vec<IctcBlock> = Vec::new();

--- a/src/rules/if_change_then_change.rs
+++ b/src/rules/if_change_then_change.rs
@@ -199,8 +199,18 @@ pub fn ictc(run: &Run, upstream: &str) -> anyhow::Result<Vec<diagnostic::Diagnos
     for block in &blocks {
         if let Some(change) = &block.thenchange {
             match change {
-                ThenChange::RemoteFile(_remote_file) => {
-                    todo!("build support for remote file")
+                ThenChange::RemoteFile(remote_file) => {
+                    diagnostics.push(diagnostic::Diagnostic {
+                        path: block.path.to_str().unwrap().to_string(),
+                        range: Some(block.get_range()),
+                        severity: diagnostic::Severity::Warning,
+                        code: "if-change-remote-not-supported".to_string(),
+                        message: format!(
+                            "ThenChange references remote file {} which is not yet supported",
+                            remote_file,
+                        ),
+                        replacements: None,
+                    });
                 }
                 ThenChange::RepoFile(local_file) => {
                     // Check if the repo file exists - if it was deleted this is a warning

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,4 +1,16 @@
+use crate::diagnostic;
+use crate::run::Run;
+
 pub mod if_change_then_change;
 pub mod never_edit;
 pub mod no_curly_quotes;
 pub mod pls_no_land;
+
+pub type RuleFn = fn(&Run, &str) -> anyhow::Result<Vec<diagnostic::Diagnostic>>;
+
+pub const RULES: &[(&str, RuleFn)] = &[
+    ("pls_no_land", pls_no_land::pls_no_land),
+    ("if_change_then_change", if_change_then_change::ictc),
+    ("never_edit", never_edit::never_edit),
+    ("no_curly_quotes", no_curly_quotes::no_curly_quotes),
+];

--- a/src/rules/never_edit.rs
+++ b/src/rules/never_edit.rs
@@ -8,6 +8,8 @@ use log::debug;
 use log::trace;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
+use std::path::Path;
+
 use crate::diagnostic;
 use crate::git;
 
@@ -115,7 +117,7 @@ pub fn never_edit(run: &Run, upstream: &str) -> anyhow::Result<Vec<diagnostic::D
     let modified = git::modified_since(upstream, None)?;
 
     for protected_file in &protected_files {
-        if let Some(status) = modified.paths.get(protected_file) {
+        if let Some(status) = modified.paths.get(Path::new(protected_file)) {
             match status {
                 FileStatus::Modified => {
                     let replacements = build_restore_replacement(upstream, protected_file);

--- a/src/rules/pls_no_land.rs
+++ b/src/rules/pls_no_land.rs
@@ -1,6 +1,4 @@
 // trunk-ignore-all(trunk-toolbox/do-not-land,trunk-toolbox/todo)
-extern crate regex;
-
 use crate::diagnostic;
 use crate::run::Run;
 use anyhow::Context;
@@ -11,11 +9,12 @@ use std::fs::File;
 use std::io::Read;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
-lazy_static::lazy_static! {
-    static ref DNL_RE: Regex = Regex::new(r"(?i)(DO[\s_-]*NOT[\s_-]*LAND)").unwrap();
-    static ref TODO_RE: Regex = Regex::new(r"(?i)(TODO|FIXME)(\W+.*)?$").unwrap();
-}
+static DNL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)(DO[\s_-]*NOT[\s_-]*LAND)").unwrap());
+static TODO_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)(TODO|FIXME)(\W+.*)?$").unwrap());
 
 pub fn is_binary_file(path: &PathBuf) -> std::io::Result<bool> {
     let mut file = File::open(path)?;

--- a/src/rules/pls_no_land.rs
+++ b/src/rules/pls_no_land.rs
@@ -32,7 +32,7 @@ pub fn is_ignored_file(path: &Path) -> bool {
 // Checks for $re and other forms thereof in source code
 //
 // Note that this is named "pls_no_land" to avoid causing DNL matches everywhere in trunk-toolbox.
-pub fn pls_no_land(run: &Run) -> anyhow::Result<Vec<diagnostic::Diagnostic>> {
+pub fn pls_no_land(run: &Run, _upstream: &str) -> anyhow::Result<Vec<diagnostic::Diagnostic>> {
     let dnl_config = &run.config.donotland;
     let todo_config = &run.config.todo;
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -46,6 +46,10 @@ pub struct Cli {
     #[clap(long)]
     /// optional path to write results to
     pub results: Option<String>,
+
+    #[clap(long)]
+    /// signal that this run is analyzing the upstream baseline
+    pub upstream_mode: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -60,10 +64,11 @@ pub struct Run {
     pub config: Conf,
     pub config_path: String,
     pub cache_dir: String,
+    pub upstream_mode: bool,
 }
 
 impl Run {
     pub fn is_upstream(&self) -> bool {
-        self.cache_dir.ends_with("-upstream")
+        self.upstream_mode
     }
 }

--- a/tests/integration_testing.rs
+++ b/tests/integration_testing.rs
@@ -246,7 +246,10 @@ impl TestRepo {
 
         let modified_paths =
             horton::git::modified_since(upstream_ref, Some(self.dir.path()))?.paths;
-        let files: Vec<String> = modified_paths.keys().map(|key| key.to_string()).collect();
+        let files: Vec<String> = modified_paths
+            .keys()
+            .map(|key| key.to_string_lossy().to_string())
+            .collect();
 
         cmd.arg("--upstream")
             .arg(upstream_ref)


### PR DESCRIPTION
## Summary

Batch of design improvements and cleanup (absorbs #68 which was folded in during rebasing):

**Rule orchestration**
- `RULES` array + `RuleFn` type alias in `src/rules/mod.rs` — all rules share `fn(&Run, &str) -> Result<Vec<Diagnostic>>`. Adding a rule is one line.
- `main.rs` replaces 4 manual result variables with an iterator over `RULES`. Per-rule error context added via `anyhow::Context`.

**Bug fixes**
- `todo!()` panic in ICTC → `if-change-remote-not-supported` warning diagnostic.
- `--upstream-mode` CLI flag replaces brittle `cache_dir.ends_with("-upstream")` heuristic (legacy check kept for backwards compat).

**Dependency cleanup**
- `lazy_static` → `std::sync::LazyLock` (stable since Rust 1.80) across 3 files. Drops the direct dep.
- `FileChanges.paths`: `HashMap<String, FileStatus>` → `HashMap<PathBuf, FileStatus>` for type safety.

**CI fixes**
- Restored `trunk_check_runner` job (required by branch protection).
- Bumped `clippy@1.76.0` / `rustfmt@1.76.0` → `@1.85.0` in `.trunk/trunk.yaml` to match toolchain (1.76's cargo can't parse Cargo.lock v4).

## Test plan
- [x] `cargo build --tests` clean
- [x] `cargo fmt --check` clean
- [x] `cargo run -- genconfig` unchanged
- [x] `--upstream-mode` in `--help`
- [ ] CI

https://claude.ai/code/session_014Ev8EeSctAKfjw3tX14weS