### PR TITLE
Add workspace path parameter to git operations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -192,6 +192,7 @@ fn build_output(cli: Cli, start: &Instant) -> anyhow::Result<(String, Option<any
         config_path: toolbox_toml,
         cache_dir: cli.cache_dir.clone(),
         upstream_mode,
+        workspace: cli.workspace,
     };
 
     let mut results: Vec<anyhow::Result<Vec<diagnostic::Diagnostic>>> =

--- a/src/rules/if_change_then_change.rs
+++ b/src/rules/if_change_then_change.rs
@@ -152,7 +152,7 @@ pub fn ictc(run: &Run, upstream: &str) -> anyhow::Result<Vec<diagnostic::Diagnos
         return Ok(vec![]);
     }
 
-    let modified = git::modified_since(upstream, None)?;
+    let modified = git::modified_since(upstream, run.workspace())?;
     let hunks = &modified.hunks;
 
     log::trace!("modified stats, per libgit2:\n{:#?}", modified);

--- a/src/rules/never_edit.rs
+++ b/src/rules/never_edit.rs
@@ -148,13 +148,13 @@ pub fn never_edit(run: &Run, upstream: &str) -> anyhow::Result<Vec<diagnostic::D
         return Ok(diagnostics);
     }
 
-    let workdir = git::repo_workdir(None)?;
+    let workdir = git::repo_workdir(run.workspace())?;
 
     // Validate patterns against the list of git-tracked files anchored at the
     // workspace root rather than walking the filesystem from the process cwd.
     // This keeps validation in lockstep with matching, which uses workspace-relative paths.
     debug!("verifying protected paths are valid and exist");
-    let tracked = git::tracked_files(None).unwrap_or_default();
+    let tracked = git::tracked_files(run.workspace()).unwrap_or_default();
     for glob_path in &config.paths {
         let pat = normalize_never_edit_glob_pattern(glob_path, &workdir);
         let matches_something = tracked.iter().any(|file| {
@@ -199,13 +199,14 @@ pub fn never_edit(run: &Run, upstream: &str) -> anyhow::Result<Vec<diagnostic::D
         protected_files.len()
     );
 
-    let modified = git::modified_since(upstream, None)?;
+    let modified = git::modified_since(upstream, run.workspace())?;
 
     for protected_file in &protected_files {
         if let Some(status) = modified.paths.get(Path::new(protected_file)) {
             match status {
                 FileStatus::Modified => {
-                    let replacements = build_restore_replacement(upstream, protected_file);
+                    let replacements =
+                        build_restore_replacement(upstream, protected_file, run.workspace());
                     diagnostics.push(diagnostic::Diagnostic {
                         path: protected_file.clone(),
                         range: None,
@@ -216,7 +217,8 @@ pub fn never_edit(run: &Run, upstream: &str) -> anyhow::Result<Vec<diagnostic::D
                     });
                 }
                 FileStatus::Deleted => {
-                    let replacements = build_restore_replacement(upstream, protected_file);
+                    let replacements =
+                        build_restore_replacement(upstream, protected_file, run.workspace());
                     diagnostics.push(diagnostic::Diagnostic {
                         path: protected_file.clone(),
                         range: None,
@@ -249,8 +251,9 @@ pub fn never_edit(run: &Run, upstream: &str) -> anyhow::Result<Vec<diagnostic::D
 fn build_restore_replacement(
     upstream: &str,
     file_path: &str,
+    workspace: Option<&Path>,
 ) -> Option<Vec<diagnostic::Replacement>> {
-    let upstream_text = match git::get_upstream_content(upstream, file_path, None) {
+    let upstream_text = match git::get_upstream_content(upstream, file_path, workspace) {
         Ok(content) => content,
         Err(e) => {
             debug!("failed to get upstream content for {}: {}", file_path, e);

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,6 +1,6 @@
 use crate::config::Conf;
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::builder::PossibleValue;
 use clap::{Parser, Subcommand, ValueEnum};
@@ -50,6 +50,10 @@ pub struct Cli {
     #[clap(long)]
     /// signal that this run is analyzing the upstream baseline
     pub upstream_mode: bool,
+
+    #[clap(long)]
+    /// path to the git workspace to operate on; defaults to the current working directory
+    pub workspace: Option<PathBuf>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -65,10 +69,15 @@ pub struct Run {
     pub config_path: String,
     pub cache_dir: String,
     pub upstream_mode: bool,
+    pub workspace: Option<PathBuf>,
 }
 
 impl Run {
     pub fn is_upstream(&self) -> bool {
         self.upstream_mode
+    }
+
+    pub fn workspace(&self) -> Option<&Path> {
+        self.workspace.as_deref()
     }
 }


### PR DESCRIPTION
## Summary
This PR adds support for specifying a custom git workspace path, allowing the linter to operate on repositories outside the current working directory. The workspace path is now threaded through git operations and rule implementations.

## Key Changes
- Added `--workspace` CLI flag to specify a custom git workspace path (defaults to current working directory)
- Added `workspace` field to `Run` struct with a helper method `workspace()` to access it as `Option<&Path>`
- Updated git operation calls to pass the workspace parameter:
  - `git::repo_workdir()`
  - `git::tracked_files()`
  - `git::modified_since()`
  - `git::get_upstream_content()`
- Updated rule implementations to use the workspace parameter:
  - `never_edit` rule now passes workspace to all git operations and `build_restore_replacement()`
  - `if_change_then_change` rule now passes workspace to `git::modified_since()`
- Updated `build_restore_replacement()` function signature to accept workspace parameter

## Implementation Details
- The workspace parameter is optional (`Option<&Path>`) to maintain backward compatibility
- The workspace path is properly propagated from CLI through `Run` struct to all rule functions
- Git operations can now be anchored to a specific workspace rather than always using the process's current working directory

https://claude.ai/code/session_01Lgu6orj3bmLdAWh1qisrua